### PR TITLE
exclude entry points from PS0018

### DIFF
--- a/src/Particular.Analyzers.Tests/Helpers/AnalyzerTestFixture.cs
+++ b/src/Particular.Analyzers.Tests/Helpers/AnalyzerTestFixture.cs
@@ -44,7 +44,9 @@
 
         protected ITestOutputHelper Output { get; }
 
-        protected async Task Assert(string markupCode, params string[] expectedDiagnosticIds)
+        protected Task Assert(string markupCode, params string[] expectedDiagnosticIds) => Assert(markupCode, null, expectedDiagnosticIds);
+
+        protected async Task Assert(string markupCode, CompilationOptions compilationOptions = null, params string[] expectedDiagnosticIds)
         {
             var externalTypes =
 @"namespace NServiceBus
@@ -79,7 +81,7 @@ using NServiceBus;
 
             var document = new AdhocWorkspace()
                 .AddProject("TestProject", LanguageNames.CSharp)
-                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                .WithCompilationOptions(compilationOptions ?? new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
                 .AddMetadataReferences(references)
                 .AddDocument("Externaltypes", externalTypes)
                 .Project

--- a/src/Particular.Analyzers/Cancellation/TaskReturningMethodAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/TaskReturningMethodAnalyzer.cs
@@ -52,6 +52,11 @@
                 return;
             }
 
+            if (method.IsEntryPoint())
+            {
+                return;
+            }
+
             if (!method.ReturnType.IsTask())
             {
                 return;

--- a/src/Particular.Analyzers/Extensions/MethodSymbolExtensions.cs
+++ b/src/Particular.Analyzers/Extensions/MethodSymbolExtensions.cs
@@ -28,5 +28,8 @@
                     return false;
             }
         }
+
+        public static bool IsEntryPoint(this IMethodSymbol method) =>
+            method.ContainingType.Name == "Program" && method.Name == "Main";
     }
 }


### PR DESCRIPTION
> A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext

I hit this while looking at https://github.com/Particular/Particular.GitHubExtensions/pull/13

I think we can release this as 1.1.0.