### PR TITLE
PS0008 and PS0017 both show on non-private methods with one cancellation token

### DIFF
--- a/src/Particular.Analyzers.Tests/Cancellation/MethodTokenNamesAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/MethodTokenNamesAnalyzerTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Particular.Analyzers.Tests.Cancellation
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
@@ -66,15 +67,21 @@ class MyClass : IMyInterface
 
         public MethodTokenNamesAnalyzerTests(ITestOutputHelper output) : base(output) { }
 
-        public static readonly Data SadParams = new List<string>
+        public static readonly Data SadPublicAndPrivateParams = new List<string>
+        {
+            "CancellationToken [|foo|], CancellationToken [|bar|]",
+            "object foo, CancellationToken [|bar|], CancellationToken [|baz|]",
+        }.ToData();
+
+        public static readonly Data SadPrivateOnlyParams = new List<string>
         {
             "CancellationToken [|token|]",
             "object foo, CancellationToken [|token|]",
             "CancellationToken [|foo|]",
             "object foo, CancellationToken [|bar|]",
-            "CancellationToken [|foo|], CancellationToken [|bar|]",
-            "object foo, CancellationToken [|bar|], CancellationToken [|baz|]",
         }.ToData();
+
+        public static readonly Data SadParams = SadPublicAndPrivateParams.Concat(SadPrivateOnlyParams);
 
         public static readonly Data HappyParams = new List<string>
         {
@@ -103,7 +110,7 @@ class MyClass : IMyInterface
         public Task HappyConstructors(string @params) => Assert(GetCode(constructor, @params));
 
         [Theory]
-        [MemberData(nameof(SadParams))]
+        [MemberData(nameof(SadPublicAndPrivateParams))]
         public Task SadOverrides(string @params) => Assert(GetCode(@override, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
         [Theory]
@@ -111,7 +118,7 @@ class MyClass : IMyInterface
         public Task HappyOverrides(string @params) => Assert(GetCode(@override, @params));
 
         [Theory]
-        [MemberData(nameof(SadParams))]
+        [MemberData(nameof(SadPublicAndPrivateParams))]
         public Task SadExplicits(string @params) => Assert(GetCode(@explicit, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
         [Theory]
@@ -127,7 +134,7 @@ class MyClass : IMyInterface
         public Task HappyDelegates(string @params) => Assert(GetCode(@delegate, @params));
 
         [Theory]
-        [MemberData(nameof(SadParams))]
+        [MemberData(nameof(SadPublicAndPrivateParams))]
         public Task SadInterfaceMethods(string @params) => Assert(GetCode(interfaceMethods, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
         [Theory]
@@ -136,7 +143,7 @@ class MyClass : IMyInterface
 
 #if NETCOREAPP
         [Theory]
-        [MemberData(nameof(SadParams))]
+        [MemberData(nameof(SadPublicAndPrivateParams))]
         public Task SadInterfaceDefaultMethods(string @params) => Assert(GetCode(interfaceDefaultMethods, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
         [Theory]

--- a/src/Particular.Analyzers/Cancellation/NonPrivateMethodTokenNameAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/NonPrivateMethodTokenNameAnalyzer.cs
@@ -45,6 +45,7 @@
             // cheapest checks first
             if (declaredSymbol.DeclaredAccessibility == Accessibility.Private && method.MethodKind != MethodKind.ExplicitInterfaceImplementation)
             {
+                // covered by MethodTokenNamesAnalyzer
                 return;
             }
 
@@ -57,6 +58,7 @@
 
             if (tokens.Count != 1)
             {
+                // covered by MethodTokenNamesAnalyzer
                 return;
             }
 


### PR DESCRIPTION
I first tried collapsing the two analyzers into one, raising each diagnostic as appropriate, but that made the testing harder. Arguably that's how it _should_ be done though, rather than each analyzer having some degree of knowledge of the other.

This is a simple fix which I think is probably good enough for now.

We can consider collapsing the two analyzers later, when someone has the capacity/mandate/interest in doing so.

## Before

![image](https://user-images.githubusercontent.com/677704/120627425-f370e280-c463-11eb-9611-aece690b681f.png)

## After

![image](https://user-images.githubusercontent.com/677704/120627757-45b20380-c464-11eb-956f-96961699e13d.png)
