### PR TITLE
Make AssemblyVersion MajorMinorPatch for better experience when switching between branches

### DIFF
--- a/.reposync.yml
+++ b/.reposync.yml
@@ -1,3 +1,4 @@
 exclusions:
 - LICENSE.md
 - src/NServiceBus.snk
+- GitVersion.yml

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-assembly-versioning-scheme: Major
+assembly-versioning-scheme: MajorMinorPatch
 branches:
   master:
     mode: ContinuousDeployment


### PR DESCRIPTION
Makes Particular.Analyzers match the [custom GitVersion.yml for the NServiceBus analyzers](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core.Analyzer/GitVersion.yml#L1).

The current scheme means that although the AssemblyFileVersion becomes (example) 1.2.3, the AssemblyVersion stays at 1.0.0 for all builds. So when you switch branches in Visual Studio, it gets confused because a different package still has an assembly with the same AssemblyVersion. It may contribute to the problem where switching branches means you have to restart Visual Studio (maybe with a `git clean -xdf` for good measure) in order to be able to build again.

Hopefully versioning the assembly in this way will help with that experience.

Also omit the GitVersion file from RepoSync, otherwise it would get changed right back. This does mean that the GitVersion file won't get regular updates (if they happen) from RepoStandards, but the alternative is to make the project file specify a different file, which also wouldn't receive updates, and would probably be more confusing in the long run.