### PR TITLE
project -> package

### DIFF
--- a/Package-README.md
+++ b/Package-README.md
@@ -1,3 +1,3 @@
 # About this package
 
-This project contains Roslyn analyzers that are used by the team at [Particular Software](https://particular.net).
+This package contains Roslyn analyzers that are used by the team at [Particular Software](https://particular.net).


### PR DESCRIPTION
Follow-up to #234, aligning on "package" instead of "project" in the package README.