### PR TITLE
Update workspaces version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             name: Windows
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: Linux
       fail-fast: false
     steps:
@@ -28,7 +28,9 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v3.2.0
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          8.0.x
+          6.0.x
     - name: Build
       run: dotnet build src --configuration Release
     - name: Upload packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3.2.0
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Sign NuGet packages

--- a/src/Particular.Analyzers.Tests/Cancellation/NonPrivateMethodTokenNameAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/NonPrivateMethodTokenNameAnalyzerTests.cs
@@ -67,19 +67,19 @@ class MyClass : IMyInterface
 
         public NonPrivateMethodTokenNameAnalyzerTests(ITestOutputHelper output) : base(output) { }
 
-        static readonly List<string> sadParams = new List<string>
-        {
+        static readonly List<string> sadParams =
+        [
             "CancellationToken [|token|]",
             "object foo, CancellationToken [|token|]",
-        };
+        ];
 
-        static readonly List<string> happyParams = new List<string>
-        {
+        static readonly List<string> happyParams =
+        [
             "CancellationToken cancellationToken",
             "object foo, CancellationToken cancellationToken",
             "CancellationToken token1, CancellationToken token2",
             "object foo, CancellationToken token1, CancellationToken token2",
-        };
+        ];
 
         public static Data SadData =>
             NonPrivateModifiers.SelectMany(modifiers => sadParams.Select(param => (modifiers, param))).ToData();

--- a/src/Particular.Analyzers.Tests/Cancellation/TaskReturningMethodAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/TaskReturningMethodAnalyzerTests.cs
@@ -92,26 +92,26 @@ class MyClass<T> where T : CancellableContext
     }
 }";
 
-        static readonly List<string> notTaskTypes = new List<string> { "void", "object", "IMessage" };
+        static readonly List<string> notTaskTypes = ["void", "object", "IMessage"];
 
-        static readonly List<string> taskTypes = new List<string>
-        {
+        static readonly List<string> taskTypes =
+        [
             "Task",
             "Task<string>",
 #if NET
             "ValueTask",
             "ValueTask<string>",
 #endif
-        };
+        ];
 
-        static readonly List<string> notTaskParams = new List<string>
-        {
+        static readonly List<string> notTaskParams =
+        [
             "",
             "object foo",
-        };
+        ];
 
-        static readonly List<string> taskParams = new List<string>
-        {
+        static readonly List<string> taskParams =
+        [
             "CancellationToken cancellationToken",
             "object foo, CancellationToken cancellationToken",
             "ICancellableContext foo",
@@ -120,7 +120,7 @@ class MyClass<T> where T : CancellableContext
             "CancellableContext foo, object bar",
             "T foo",
             "T foo, object bar",
-        };
+        ];
 
         public TaskReturningMethodAnalyzerTests(ITestOutputHelper output) : base(output) { }
 

--- a/src/Particular.Analyzers.Tests/Cancellation/TokenAccessibilityAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/TokenAccessibilityAnalyzerTests.cs
@@ -62,19 +62,19 @@ class MyClass : IMyInterface
 }}";
 #endif
 
-        static readonly List<string> privateParams = new List<string>
-        {
+        static readonly List<string> privateParams =
+        [
             "object foo, CancellationToken [|cancellationToken|]",
             "object foo, CancellationToken [|cancellationToken1|], CancellationToken [|cancellationToken2|]",
             "object foo, CancellationToken [|cancellationToken1|], CancellationToken [|cancellationToken2|], CancellationToken [|cancellationToken3|]",
-        };
+        ];
 
-        static readonly List<string> nonPrivateParams = new List<string>
-        {
+        static readonly List<string> nonPrivateParams =
+        [
             "object foo, CancellationToken [|cancellationToken|] = default",
             "object foo, CancellationToken [|cancellationToken1|] = default, CancellationToken [|cancellationToken2|] = default",
             "object foo, CancellationToken [|cancellationToken1|] = default, CancellationToken [|cancellationToken2|] = default, CancellationToken [|cancellationToken3|] = default",
-        };
+        ];
 
         public TokenAccessibilityAnalyzerTests(ITestOutputHelper output) : base(output) { }
 

--- a/src/Particular.Analyzers.Tests/Helpers/AnalyzerTestFixture.cs
+++ b/src/Particular.Analyzers.Tests/Helpers/AnalyzerTestFixture.cs
@@ -20,19 +20,19 @@
 
         AnalyzerTestFixture() { }
 
-        protected static readonly List<string> PrivateModifiers = new List<string> { "", "private" };
+        protected static readonly List<string> PrivateModifiers = ["", "private"];
 
-        protected static readonly List<string> NonPrivateModifiers = new List<string> { "public", "protected", "internal", "protected internal", "private protected" };
+        protected static readonly List<string> NonPrivateModifiers = ["public", "protected", "internal", "protected internal", "private protected"];
 
-        protected static readonly List<string> InterfacePrivateModifiers = new List<string>
-        {
+        protected static readonly List<string> InterfacePrivateModifiers =
+        [
 #if NET
             "private",
 #endif
-        };
+        ];
 
-        protected static readonly List<string> InterfaceNonPrivateModifiers = new List<string>
-        {
+        protected static readonly List<string> InterfaceNonPrivateModifiers =
+        [
             "",
             "public",
             "internal",
@@ -41,7 +41,7 @@
             "protected internal",
             "private protected",
 #endif
-        };
+        ];
 
         protected ITestOutputHelper Output { get; }
 
@@ -147,7 +147,7 @@ using NServiceBus;
         {
             if (markupCode == null)
             {
-                return (null, new List<TextSpan>());
+                return (null, []);
             }
 
             var code = new StringBuilder();

--- a/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
+++ b/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
+++ b/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
+++ b/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Particular.Analyzers.Tests/TypeNameAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/TypeNameAnalyzerTests.cs
@@ -16,31 +16,31 @@
 
         public TypeNameAnalyzerTests(ITestOutputHelper output) : base(output) { }
 
-        static readonly List<string> interfaceKeywords = new List<string>
-        {
+        static readonly List<string> interfaceKeywords =
+        [
            "interface",
-        };
+        ];
 
-        static readonly List<string> nonInterfaceKeywords = new List<string>
-        {
+        static readonly List<string> nonInterfaceKeywords =
+        [
             "class",
             "enum",
             "struct",
             "record",
-        };
+        ];
 
-        static readonly List<string> interfaceNames = new List<string>
-        {
+        static readonly List<string> interfaceNames =
+        [
             "ISomething",
             "II",
-        };
+        ];
 
-        static readonly List<string> nonInterfaceNames = new List<string>
-        {
+        static readonly List<string> nonInterfaceNames =
+        [
             "Something",
             "International",
             "I",
-        };
+        ];
 
         public static Data SadTypesData =>
             nonInterfaceKeywords.SelectMany(keyword => interfaceNames.Select(name => (keyword, name))).ToData();

--- a/src/Particular.Analyzers/Particular.Analyzers.csproj
+++ b/src/Particular.Analyzers/Particular.Analyzers.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -13,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Particular.Analyzers/Particular.Analyzers.csproj
+++ b/src/Particular.Analyzers/Particular.Analyzers.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="3.0.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="4.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Particular.Analyzers/Particular.Analyzers.csproj
+++ b/src/Particular.Analyzers/Particular.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Link="$(AssemblyName).dll" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.7/cs" Link="$(AssemblyName).dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="UseMajorMinorPatchForAssemblyVersion" AfterTargets="MinVer">


### PR DESCRIPTION
This updates the Workspaces package to 4.7.0, which is the current latest RTM version, and corresponds to Visual Studio 2022 17.7.

One thing I have changed here is that the package path now includes the Roslyn version, which lets the tooling pick the most appropriate version. This could be expanded on in the future if needed to support a wider range of versions, while still updating to take advantage of newer versions.

I also went ahead and updated the workflow files and updated Particular.Packaging.