### PR TITLE
New analyzer: Structured logging tokens cannot be repeated

### DIFF
--- a/src/Particular.Analyzers.Tests/LoggingAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/LoggingAnalyzerTests.cs
@@ -1,0 +1,243 @@
+﻿namespace Particular.Analyzers.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Particular.Analyzers.Tests.Helpers;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class LoggingAnalyzerTests : AnalyzerTestFixture<LoggingAnalyzer>
+    {
+        public LoggingAnalyzerTests(ITestOutputHelper output) : base(output) { }
+
+        [Theory]
+        [InlineData("DebugFormat")]
+        [InlineData("InfoFormat")]
+        [InlineData("WarnFormat")]
+        [InlineData("ErrorFormat")]
+        [InlineData("FatalFormat")]
+        public Task NServiceBusLogging(string methodName)
+        {
+            var template = @"
+
+public class Foo
+{
+    public void Bar(NServiceBus.Logging.ILog log)
+    {
+        // All matched up, good!
+        log.DebugFormat(""{0}"", 0);
+        log.DebugFormat(""{0} {1}"", 0, 1);
+        log.DebugFormat(""{0} {1} {2}"", 0, 1, 2);
+        log.DebugFormat(""{0} {1} {2} {3}}"", 0, 1, 2, 3);
+        log.DebugFormat(""{0} {1} {2} {3} {4}"", 0, 1, 2, 3, 4);
+
+        // Even OK to have extra, as far as the analyzer is concerned
+        log.DebugFormat(""{0}"", 0, 1, 2, 3, 4, 5);
+
+        // Not OK to have repeated
+        [|log.DebugFormat(""{0} {0}"", 0)|];
+        // Not even if a second param is provided
+        [|log.DebugFormat(""{0} {0}"", 0, 1)|];
+
+        // Doesn't matter if you rename the variable;
+        var logger = log;
+        [|logger.DebugFormat(""{0} {0}"", 0, 1)|];
+
+        // Actual problematic line from Gateway (with curly brace red herring) that caused https://github.com/Particular/NServiceBus.Gateway/issues/529
+        var identity = ""COMPUTERNAME"";
+        [|logger.DebugFormat(
+@""Did not attempt to grant user '{0}' HttpListener permissions since process is not running with elevate privileges. Processing will continue.
+To manually perform this action run the following command for each url from an admin console:
+netsh http add urlacl url={{http://URL:PORT/[PATH/] | https://URL:PORT/[PATH/]}} user=""""{0}"""""", identity)|];
+
+        // Fixed version
+        logger.DebugFormat(
+@""Did not attempt to grant user '{0}' HttpListener permissions since process is not running with elevate privileges. Processing will continue.
+To manually perform this action run the following command for each url from an admin console:
+netsh http add urlacl url={{http://URL:PORT/[PATH/] | https://URL:PORT/[PATH/]}} user=""""{1}"""""", identity, identity);
+    }
+}
+
+namespace NServiceBus.Logging
+{
+    public interface ILog
+    {
+        public void DebugFormat(string format, params object[] args);
+    }
+}";
+
+            var code = template.Replace("DebugFormat", methodName);
+            return Assert(code, DiagnosticIds.StructuredLoggingWithRepeatedToken);
+        }
+
+        [Theory]
+        [InlineData("LogDebug", "Debug")]
+        [InlineData("LogTrace", "Trace")]
+        [InlineData("LogInformation", "Information")]
+        [InlineData("LogWarning", "Warning")]
+        [InlineData("LogError", "Error")]
+        [InlineData("LogCritical", "Critical")]
+        public Task MicrosoftExtensionsLoggingAllOk(string methodName, string logLevel)
+        {
+            var template = @"
+namespace Code
+{
+    using Microsoft.Extensions.Logging;
+
+    public class State { }
+
+    public class Fo
+    {
+        public void Bar(ILogger log)
+        {
+            var eventId = EventId.None;
+            var x = new Exception("""");
+            var state = new State();
+
+            // Root method that doesn't use formatting
+            log.Log(LogLevel.LOGLEVEL, eventId, state, x, (a, b) => ""Formatted"");
+
+            // Basic method
+            log.METHODNAME(""plain message"");
+            log.METHODNAME(""{0}"", 0);
+            log.METHODNAME(""{0} {1}"", 0, 1);
+            log.METHODNAME(""{0} {1} {2}"", 0, 1, 2);
+            log.Log(LogLevel.LOGLEVEL, ""plain message"");
+            log.Log(LogLevel.LOGLEVEL, ""{0}"", 0);
+            log.Log(LogLevel.LOGLEVEL, ""{0} {1}"", 0, 1);
+            log.Log(LogLevel.LOGLEVEL, ""{0} {1} {2}"", 0, 1, 2);
+
+            // With EventId
+            log.METHODNAME(eventId, ""plain message"");
+            log.METHODNAME(eventId, ""{0}"", 0);
+            log.METHODNAME(eventId, ""{0} {1}"", 0, 1);
+            log.METHODNAME(eventId, ""{0} {1} {2}"", 0, 1, 2);
+            log.Log(LogLevel.LOGLEVEL, eventId, ""plain message"");
+            log.Log(LogLevel.LOGLEVEL, eventId, ""{0}"", 0);
+            log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {1}"", 0, 1);
+            log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {1} {2}"", 0, 1, 2);
+
+            // With Exception
+            log.METHODNAME(x, ""plain message"");
+            log.METHODNAME(x, ""{0}"", 0);
+            log.METHODNAME(x, ""{0} {1}"", 0, 1);
+            log.METHODNAME(x, ""{0} {1} {2}"", 0, 1, 2);
+            log.Log(LogLevel.LOGLEVEL, x, ""plain message"");
+            log.Log(LogLevel.LOGLEVEL, x, ""{0}"", 0);
+            log.Log(LogLevel.LOGLEVEL, x, ""{0} {1}"", 0, 1);
+            log.Log(LogLevel.LOGLEVEL, x, ""{0} {1} {2}"", 0, 1, 2);
+
+            // With Both
+            log.METHODNAME(eventId, x, ""plain message"");
+            log.METHODNAME(eventId, x, ""{0}"", 0);
+            log.METHODNAME(eventId, x, ""{0} {1}"", 0, 1);
+            log.METHODNAME(eventId, x, ""{0} {1} {2}"", 0, 1, 2);
+            log.Log(LogLevel.LOGLEVEL, eventId, x, ""plain message"");
+            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0}"", 0);
+            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {1}"", 0, 1);
+            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {1} {2}"", 0, 1, 2);
+        }
+    }
+}
+";
+
+            var code = template.Replace("METHODNAME", methodName).Replace("LOGLEVEL", logLevel) + Environment.NewLine + MicrosoftLoggingCode;
+            return Assert(code, DiagnosticIds.StructuredLoggingWithRepeatedToken);
+        }
+
+        [Theory]
+        [InlineData("LogDebug", "Debug")]
+        [InlineData("LogTrace", "Trace")]
+        [InlineData("LogInformation", "Information")]
+        [InlineData("LogWarning", "Warning")]
+        [InlineData("LogError", "Error")]
+        [InlineData("LogCritical", "Critical")]
+        public Task MicrosoftExtensionsLoggingNotOk(string methodName, string logLevel)
+        {
+            var template = @"
+namespace Code
+{
+    using Microsoft.Extensions.Logging;
+
+    public class State { }
+
+    public class Fo
+    {
+        public void Bar(ILogger log)
+        {
+            var eventId = EventId.None;
+            var x = new Exception("""");
+            var state = new State();
+
+            // Basic method
+            [|log.METHODNAME(""{0} {0}"", 0, 1)|];
+            [|log.Log(LogLevel.LOGLEVEL, ""{0} {0}"", 0, 1)|];
+
+            // With EventId
+            [|log.METHODNAME(eventId, ""{0} {0}"", 0, 1)|];
+            [|log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {0}"", 0, 1)|];
+
+            // With Exception
+            [|log.METHODNAME(x, ""{0} {0}"", 0, 1)|];
+            [|log.Log(LogLevel.LOGLEVEL, x, ""{0} {0}"", 0, 1)|];
+
+            // With Both
+            [|log.METHODNAME(eventId, x, ""{0} {0}"", 0, 1)|];
+            [|log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {0}"", 0, 1)|];
+        }
+    }
+}
+";
+
+            var code = template.Replace("METHODNAME", methodName).Replace("LOGLEVEL", logLevel) + Environment.NewLine + MicrosoftLoggingCode;
+            return Assert(code, DiagnosticIds.StructuredLoggingWithRepeatedToken);
+        }
+
+
+        const string MicrosoftLoggingCode = @"
+#nullable enable
+namespace Microsoft.Extensions.Logging
+{
+    public enum LogLevel { Trace, Debug, Information, Warning, Error, Critical, None }
+    public readonly struct EventId
+    {
+        public static readonly EventId None = new EventId();
+    }
+    public interface ILogger
+    {
+	    void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter);
+    }
+    public static class LoggerExtensions
+    {
+        public static void LogDebug(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+        public static void LogDebug(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+        public static void LogDebug(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+        public static void LogDebug(this ILogger logger, string? message, params object?[] args) { }
+        public static void LogTrace(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+        public static void LogTrace(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+        public static void LogTrace(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+        public static void LogTrace(this ILogger logger, string? message, params object?[] args) { }
+        public static void LogInformation(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+        public static void LogInformation(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+        public static void LogInformation(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+        public static void LogInformation(this ILogger logger, string? message, params object?[] args) { }
+        public static void LogWarning(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+        public static void LogWarning(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+        public static void LogWarning(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+        public static void LogWarning(this ILogger logger, string? message, params object?[] args) { }
+        public static void LogError(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+        public static void LogError(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+        public static void LogError(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+        public static void LogError(this ILogger logger, string? message, params object?[] args) { }
+        public static void LogCritical(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+        public static void LogCritical(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+        public static void LogCritical(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+        public static void LogCritical(this ILogger logger, string? message, params object?[] args) { }
+        public static void Log(this ILogger logger, LogLevel logLevel, string? message, params object?[] args) { }
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, string? message, params object?[] args) { }
+        public static void Log(this ILogger logger, LogLevel logLevel, Exception? exception, string? message, params object?[] args) { }
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+    }
+}";
+    }
+}

--- a/src/Particular.Analyzers.Tests/LoggingAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/LoggingAnalyzerTests.cs
@@ -18,55 +18,54 @@
         [InlineData("FatalFormat")]
         public Task NServiceBusLogging(string methodName)
         {
-            var template = @"
+            var code = $$$""""
+            public class Foo
+            {
+                public void Bar(NServiceBus.Logging.ILog log)
+                {
+                    // All matched up, good!
+                    log.{{{methodName}}}("{0}", 0);
+                    log.{{{methodName}}}("{0} {1}", 0, 1);
+                    log.{{{methodName}}}("{0} {1} {2}", 0, 1, 2);
+                    log.{{{methodName}}}("{0} {1} {2} {3}}", 0, 1, 2, 3);
+                    log.{{{methodName}}}("{0} {1} {2} {3} {4}", 0, 1, 2, 3, 4);
 
-public class Foo
-{
-    public void Bar(NServiceBus.Logging.ILog log)
-    {
-        // All matched up, good!
-        log.DebugFormat(""{0}"", 0);
-        log.DebugFormat(""{0} {1}"", 0, 1);
-        log.DebugFormat(""{0} {1} {2}"", 0, 1, 2);
-        log.DebugFormat(""{0} {1} {2} {3}}"", 0, 1, 2, 3);
-        log.DebugFormat(""{0} {1} {2} {3} {4}"", 0, 1, 2, 3, 4);
+                    // Even OK to have extra, as far as the analyzer is concerned
+                    log.{{{methodName}}}("{0}", 0, 1, 2, 3, 4, 5);
 
-        // Even OK to have extra, as far as the analyzer is concerned
-        log.DebugFormat(""{0}"", 0, 1, 2, 3, 4, 5);
+                    // Not OK to have repeated
+                    [|log.{{{methodName}}}("{0} {0}", 0)|];
+                    // Not even if a second param is provided
+                    [|log.{{{methodName}}}("{0} {0}", 0, 1)|];
 
-        // Not OK to have repeated
-        [|log.DebugFormat(""{0} {0}"", 0)|];
-        // Not even if a second param is provided
-        [|log.DebugFormat(""{0} {0}"", 0, 1)|];
+                    // Doesn't matter if you rename the variable;
+                    var logger = log;
+                    [|logger.{{{methodName}}}("{0} {0}", 0, 1)|];
 
-        // Doesn't matter if you rename the variable;
-        var logger = log;
-        [|logger.DebugFormat(""{0} {0}"", 0, 1)|];
+                    // Actual problematic line from Gateway (with curly brace red herring) that caused https://github.com/Particular/NServiceBus.Gateway/issues/529
+                    var identity = "COMPUTERNAME";
+                    [|logger.{{{methodName}}}(
+            @"Did not attempt to grant user '{0}' HttpListener permissions since process is not running with elevate privileges. Processing will continue.
+            To manually perform this action run the following command for each url from an admin console:
+            netsh http add urlacl url={{http://URL:PORT/[PATH/] | https://URL:PORT/[PATH/]}} user=""{0}""", identity)|];
 
-        // Actual problematic line from Gateway (with curly brace red herring) that caused https://github.com/Particular/NServiceBus.Gateway/issues/529
-        var identity = ""COMPUTERNAME"";
-        [|logger.DebugFormat(
-@""Did not attempt to grant user '{0}' HttpListener permissions since process is not running with elevate privileges. Processing will continue.
-To manually perform this action run the following command for each url from an admin console:
-netsh http add urlacl url={{http://URL:PORT/[PATH/] | https://URL:PORT/[PATH/]}} user=""""{0}"""""", identity)|];
+                    // Fixed version
+                    logger.{{{methodName}}}(
+            @"Did not attempt to grant user '{0}' HttpListener permissions since process is not running with elevate privileges. Processing will continue.
+            To manually perform this action run the following command for each url from an admin console:
+            netsh http add urlacl url={{http://URL:PORT/[PATH/] | https://URL:PORT/[PATH/]}} user=""{1}""", identity, identity);
+                }
+            }
 
-        // Fixed version
-        logger.DebugFormat(
-@""Did not attempt to grant user '{0}' HttpListener permissions since process is not running with elevate privileges. Processing will continue.
-To manually perform this action run the following command for each url from an admin console:
-netsh http add urlacl url={{http://URL:PORT/[PATH/] | https://URL:PORT/[PATH/]}} user=""""{1}"""""", identity, identity);
-    }
-}
+            namespace NServiceBus.Logging
+            {
+                public interface ILog
+                {
+                    public void {{{methodName}}}(string format, params object[] args);
+                }
+            }
+            """";
 
-namespace NServiceBus.Logging
-{
-    public interface ILog
-    {
-        public void DebugFormat(string format, params object[] args);
-    }
-}";
-
-            var code = template.Replace("DebugFormat", methodName);
             return Assert(code, DiagnosticIds.StructuredLoggingWithRepeatedToken);
         }
 
@@ -79,81 +78,80 @@ namespace NServiceBus.Logging
         [InlineData("LogCritical", "Critical")]
         public Task MicrosoftExtensionsLoggingAllOk(string methodName, string logLevel)
         {
-            var template = @"
-namespace Code
-{
-    using Microsoft.Extensions.Logging;
+            var code = $$"""
+            namespace Code
+            {
+                using Microsoft.Extensions.Logging;
 
-    public class State { }
+                public class State { }
 
-    public class Fo
-    {
-        public void Bar(ILogger log)
-        {
-            var eventId = EventId.None;
-            var x = new Exception("""");
-            var state = new State();
+                public class Fo
+                {
+                    public void Bar(ILogger log)
+                    {
+                        var eventId = EventId.None;
+                        var x = new Exception("");
+                        var state = new State();
 
-            // Root method that doesn't use formatting
-            log.Log(LogLevel.LOGLEVEL, eventId, state, x, (a, b) => ""Formatted"");
+                        // Root method that doesn't use formatting
+                        log.Log(LogLevel.{{logLevel}}, eventId, state, x, (a, b) => "Formatted");
 
-            // Basic method
-            log.METHODNAME(""plain message"");
-            log.METHODNAME(""{0}"", 0);
-            log.METHODNAME(""{0} {1}"", 0, 1);
-            log.METHODNAME(""{0} {1} {2}"", 0, 1, 2);
-            log.Log(LogLevel.LOGLEVEL, ""plain message"");
-            log.Log(LogLevel.LOGLEVEL, ""{0}"", 0);
-            log.Log(LogLevel.LOGLEVEL, ""{0} {1}"", 0, 1);
-            log.Log(LogLevel.LOGLEVEL, ""{0} {1} {2}"", 0, 1, 2);
-            log.Log(LogLevel.LOGLEVEL, ""{One}"", 1);
-            log.Log(LogLevel.LOGLEVEL, ""{One} {Two}"", 1, 2);
-            log.Log(LogLevel.LOGLEVEL, ""{One} {Two} {Three}"", 1, 2, 3);
+                        // Basic method
+                        log.{{methodName}}("plain message");
+                        log.{{methodName}}("{0}", 0);
+                        log.{{methodName}}("{0} {1}", 0, 1);
+                        log.{{methodName}}("{0} {1} {2}", 0, 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, "plain message");
+                        log.Log(LogLevel.{{logLevel}}, "{0}", 0);
+                        log.Log(LogLevel.{{logLevel}}, "{0} {1}", 0, 1);
+                        log.Log(LogLevel.{{logLevel}}, "{0} {1} {2}", 0, 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, "{One}", 1);
+                        log.Log(LogLevel.{{logLevel}}, "{One} {Two}", 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, "{One} {Two} {Three}", 1, 2, 3);
 
-            // With EventId
-            log.METHODNAME(eventId, ""plain message"");
-            log.METHODNAME(eventId, ""{0}"", 0);
-            log.METHODNAME(eventId, ""{0} {1}"", 0, 1);
-            log.METHODNAME(eventId, ""{0} {1} {2}"", 0, 1, 2);
-            log.Log(LogLevel.LOGLEVEL, eventId, ""plain message"");
-            log.Log(LogLevel.LOGLEVEL, eventId, ""{0}"", 0);
-            log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {1}"", 0, 1);
-            log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {1} {2}"", 0, 1, 2);
-            log.Log(LogLevel.LOGLEVEL, eventId, ""{One}"", 1);
-            log.Log(LogLevel.LOGLEVEL, eventId, ""{One} {Two}"", 1, 2);
-            log.Log(LogLevel.LOGLEVEL, eventId, ""{One} {Two} {Three}"", 1, 2, 3);
+                        // With EventId
+                        log.{{methodName}}(eventId, "plain message");
+                        log.{{methodName}}(eventId, "{0}", 0);
+                        log.{{methodName}}(eventId, "{0} {1}", 0, 1);
+                        log.{{methodName}}(eventId, "{0} {1} {2}", 0, 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, eventId, "plain message");
+                        log.Log(LogLevel.{{logLevel}}, eventId, "{0}", 0);
+                        log.Log(LogLevel.{{logLevel}}, eventId, "{0} {1}", 0, 1);
+                        log.Log(LogLevel.{{logLevel}}, eventId, "{0} {1} {2}", 0, 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, eventId, "{One}", 1);
+                        log.Log(LogLevel.{{logLevel}}, eventId, "{One} {Two}", 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, eventId, "{One} {Two} {Three}", 1, 2, 3);
 
-            // With Exception
-            log.METHODNAME(x, ""plain message"");
-            log.METHODNAME(x, ""{0}"", 0);
-            log.METHODNAME(x, ""{0} {1}"", 0, 1);
-            log.METHODNAME(x, ""{0} {1} {2}"", 0, 1, 2);
-            log.Log(LogLevel.LOGLEVEL, x, ""plain message"");
-            log.Log(LogLevel.LOGLEVEL, x, ""{0}"", 0);
-            log.Log(LogLevel.LOGLEVEL, x, ""{0} {1}"", 0, 1);
-            log.Log(LogLevel.LOGLEVEL, x, ""{0} {1} {2}"", 0, 1, 2);
-            log.Log(LogLevel.LOGLEVEL, x, ""{One}"", 1);
-            log.Log(LogLevel.LOGLEVEL, x, ""{One} {Two}"", 1, 2);
-            log.Log(LogLevel.LOGLEVEL, x, ""{One} {Two} {Three}"", 1, 2, 3);
+                        // With Exception
+                        log.{{methodName}}(x, "plain message");
+                        log.{{methodName}}(x, "{0}", 0);
+                        log.{{methodName}}(x, "{0} {1}", 0, 1);
+                        log.{{methodName}}(x, "{0} {1} {2}", 0, 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, x, "plain message");
+                        log.Log(LogLevel.{{logLevel}}, x, "{0}", 0);
+                        log.Log(LogLevel.{{logLevel}}, x, "{0} {1}", 0, 1);
+                        log.Log(LogLevel.{{logLevel}}, x, "{0} {1} {2}", 0, 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, x, "{One}", 1);
+                        log.Log(LogLevel.{{logLevel}}, x, "{One} {Two}", 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, x, "{One} {Two} {Three}", 1, 2, 3);
 
-            // With Both
-            log.METHODNAME(eventId, x, ""plain message"");
-            log.METHODNAME(eventId, x, ""{0}"", 0);
-            log.METHODNAME(eventId, x, ""{0} {1}"", 0, 1);
-            log.METHODNAME(eventId, x, ""{0} {1} {2}"", 0, 1, 2);
-            log.Log(LogLevel.LOGLEVEL, eventId, x, ""plain message"");
-            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0}"", 0);
-            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {1}"", 0, 1);
-            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {1} {2}"", 0, 1, 2);
-            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{One}"", 1);
-            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{One} {Two}"", 1, 2);
-            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{One} {Two} {Three}"", 1, 2, 3);
-        }
-    }
-}
-";
+                        // With Both
+                        log.{{methodName}}(eventId, x, "plain message");
+                        log.{{methodName}}(eventId, x, "{0}", 0);
+                        log.{{methodName}}(eventId, x, "{0} {1}", 0, 1);
+                        log.{{methodName}}(eventId, x, "{0} {1} {2}", 0, 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, eventId, x, "plain message");
+                        log.Log(LogLevel.{{logLevel}}, eventId, x, "{0}", 0);
+                        log.Log(LogLevel.{{logLevel}}, eventId, x, "{0} {1}", 0, 1);
+                        log.Log(LogLevel.{{logLevel}}, eventId, x, "{0} {1} {2}", 0, 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, eventId, x, "{One}", 1);
+                        log.Log(LogLevel.{{logLevel}}, eventId, x, "{One} {Two}", 1, 2);
+                        log.Log(LogLevel.{{logLevel}}, eventId, x, "{One} {Two} {Three}", 1, 2, 3);
+                    }
+                }
+            }
+            """ + Environment.NewLine + MicrosoftLoggingCode;
 
-            var code = template.Replace("METHODNAME", methodName).Replace("LOGLEVEL", logLevel) + Environment.NewLine + MicrosoftLoggingCode;
             return Assert(code, DiagnosticIds.StructuredLoggingWithRepeatedToken);
         }
 
@@ -166,94 +164,94 @@ namespace Code
         [InlineData("LogCritical", "Critical")]
         public Task MicrosoftExtensionsLoggingNotOk(string methodName, string logLevel)
         {
-            var template = @"
-namespace Code
-{
-    using Microsoft.Extensions.Logging;
+            var code = $$"""
+            namespace Code
+            {
+                using Microsoft.Extensions.Logging;
 
-    public class State { }
+                public class State { }
 
-    public class Fo
-    {
-        public void Bar(ILogger log)
-        {
-            var eventId = EventId.None;
-            var x = new Exception("""");
-            var state = new State();
+                public class Fo
+                {
+                    public void Bar(ILogger log)
+                    {
+                        var eventId = EventId.None;
+                        var x = new Exception("");
+                        var state = new State();
 
-            // Basic method
-            [|log.METHODNAME(""{0} {0}"", 0, 1)|];
-            [|log.Log(LogLevel.LOGLEVEL, ""{0} {0}"", 0, 1)|];
-            [|log.Log(LogLevel.LOGLEVEL, ""{Repeated} {Repeated}"", 0)|];
+                        // Basic method
+                        [|log.{{methodName}}("{0} {0}", 0, 1)|];
+                        [|log.Log(LogLevel.{{logLevel}}, "{0} {0}", 0, 1)|];
+                        [|log.Log(LogLevel.{{logLevel}}, "{Repeated} {Repeated}", 0)|];
 
-            // With EventId
-            [|log.METHODNAME(eventId, ""{0} {0}"", 0, 1)|];
-            [|log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {0}"", 0, 1)|];
-            [|log.Log(LogLevel.LOGLEVEL, eventId, ""{Repeated} {Repeated}"", 0)|];
+                        // With EventId
+                        [|log.{{methodName}}(eventId, "{0} {0}", 0, 1)|];
+                        [|log.Log(LogLevel.{{logLevel}}, eventId, "{0} {0}", 0, 1)|];
+                        [|log.Log(LogLevel.{{logLevel}}, eventId, "{Repeated} {Repeated}", 0)|];
 
-            // With Exception
-            [|log.METHODNAME(x, ""{0} {0}"", 0, 1)|];
-            [|log.Log(LogLevel.LOGLEVEL, x, ""{0} {0}"", 0, 1)|];
-            [|log.Log(LogLevel.LOGLEVEL, x, ""{Repeated} {Repeated}"", 0)|];
+                        // With Exception
+                        [|log.{{methodName}}(x, "{0} {0}", 0, 1)|];
+                        [|log.Log(LogLevel.{{logLevel}}, x, "{0} {0}", 0, 1)|];
+                        [|log.Log(LogLevel.{{logLevel}}, x, "{Repeated} {Repeated}", 0)|];
 
-            // With Both
-            [|log.METHODNAME(eventId, x, ""{0} {0}"", 0, 1)|];
-            [|log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {0}"", 0, 1)|];
-            [|log.Log(LogLevel.LOGLEVEL, eventId, x, ""{Repeated} {Repeated}"", 0)|];
-        }
-    }
-}
-";
+                        // With Both
+                        [|log.{{methodName}}(eventId, x, "{0} {0}", 0, 1)|];
+                        [|log.Log(LogLevel.{{logLevel}}, eventId, x, "{0} {0}", 0, 1)|];
+                        [|log.Log(LogLevel.{{logLevel}}, eventId, x, "{Repeated} {Repeated}", 0)|];
+                    }
+                }
+            }
+            """ + Environment.NewLine + MicrosoftLoggingCode;
 
-            var code = template.Replace("METHODNAME", methodName).Replace("LOGLEVEL", logLevel) + Environment.NewLine + MicrosoftLoggingCode;
             return Assert(code, DiagnosticIds.StructuredLoggingWithRepeatedToken);
         }
 
 
-        const string MicrosoftLoggingCode = @"
-#nullable enable
-namespace Microsoft.Extensions.Logging
-{
-    public enum LogLevel { Trace, Debug, Information, Warning, Error, Critical, None }
-    public readonly struct EventId
-    {
-        public static readonly EventId None = new EventId();
-    }
-    public interface ILogger
-    {
-	    void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter);
-    }
-    public static class LoggerExtensions
-    {
-        public static void LogDebug(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
-        public static void LogDebug(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
-        public static void LogDebug(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
-        public static void LogDebug(this ILogger logger, string? message, params object?[] args) { }
-        public static void LogTrace(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
-        public static void LogTrace(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
-        public static void LogTrace(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
-        public static void LogTrace(this ILogger logger, string? message, params object?[] args) { }
-        public static void LogInformation(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
-        public static void LogInformation(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
-        public static void LogInformation(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
-        public static void LogInformation(this ILogger logger, string? message, params object?[] args) { }
-        public static void LogWarning(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
-        public static void LogWarning(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
-        public static void LogWarning(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
-        public static void LogWarning(this ILogger logger, string? message, params object?[] args) { }
-        public static void LogError(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
-        public static void LogError(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
-        public static void LogError(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
-        public static void LogError(this ILogger logger, string? message, params object?[] args) { }
-        public static void LogCritical(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
-        public static void LogCritical(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
-        public static void LogCritical(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
-        public static void LogCritical(this ILogger logger, string? message, params object?[] args) { }
-        public static void Log(this ILogger logger, LogLevel logLevel, string? message, params object?[] args) { }
-        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, string? message, params object?[] args) { }
-        public static void Log(this ILogger logger, LogLevel logLevel, Exception? exception, string? message, params object?[] args) { }
-        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string? message, params object?[] args) { }
-    }
-}";
+        const string MicrosoftLoggingCode = """
+        #nullable enable
+        namespace Microsoft.Extensions.Logging
+        {
+            public enum LogLevel { Trace, Debug, Information, Warning, Error, Critical, None }
+            public readonly struct EventId
+            {
+                public static readonly EventId None = new EventId();
+            }
+            public interface ILogger
+            {
+                void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter);
+            }
+            public static class LoggerExtensions
+            {
+                public static void LogDebug(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+                public static void LogDebug(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+                public static void LogDebug(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+                public static void LogDebug(this ILogger logger, string? message, params object?[] args) { }
+                public static void LogTrace(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+                public static void LogTrace(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+                public static void LogTrace(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+                public static void LogTrace(this ILogger logger, string? message, params object?[] args) { }
+                public static void LogInformation(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+                public static void LogInformation(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+                public static void LogInformation(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+                public static void LogInformation(this ILogger logger, string? message, params object?[] args) { }
+                public static void LogWarning(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+                public static void LogWarning(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+                public static void LogWarning(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+                public static void LogWarning(this ILogger logger, string? message, params object?[] args) { }
+                public static void LogError(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+                public static void LogError(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+                public static void LogError(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+                public static void LogError(this ILogger logger, string? message, params object?[] args) { }
+                public static void LogCritical(this ILogger logger, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+                public static void LogCritical(this ILogger logger, EventId eventId, string? message, params object?[] args) { }
+                public static void LogCritical(this ILogger logger, Exception? exception, string? message, params object?[] args) { }
+                public static void LogCritical(this ILogger logger, string? message, params object?[] args) { }
+                public static void Log(this ILogger logger, LogLevel logLevel, string? message, params object?[] args) { }
+                public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, string? message, params object?[] args) { }
+                public static void Log(this ILogger logger, LogLevel logLevel, Exception? exception, string? message, params object?[] args) { }
+                public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, Exception? exception, string? message, params object?[] args) { }
+            }
+        }
+        """;
     }
 }

--- a/src/Particular.Analyzers.Tests/LoggingAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/LoggingAnalyzerTests.cs
@@ -106,6 +106,9 @@ namespace Code
             log.Log(LogLevel.LOGLEVEL, ""{0}"", 0);
             log.Log(LogLevel.LOGLEVEL, ""{0} {1}"", 0, 1);
             log.Log(LogLevel.LOGLEVEL, ""{0} {1} {2}"", 0, 1, 2);
+            log.Log(LogLevel.LOGLEVEL, ""{One}"", 1);
+            log.Log(LogLevel.LOGLEVEL, ""{One} {Two}"", 1, 2);
+            log.Log(LogLevel.LOGLEVEL, ""{One} {Two} {Three}"", 1, 2, 3);
 
             // With EventId
             log.METHODNAME(eventId, ""plain message"");
@@ -116,6 +119,9 @@ namespace Code
             log.Log(LogLevel.LOGLEVEL, eventId, ""{0}"", 0);
             log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {1}"", 0, 1);
             log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {1} {2}"", 0, 1, 2);
+            log.Log(LogLevel.LOGLEVEL, eventId, ""{One}"", 1);
+            log.Log(LogLevel.LOGLEVEL, eventId, ""{One} {Two}"", 1, 2);
+            log.Log(LogLevel.LOGLEVEL, eventId, ""{One} {Two} {Three}"", 1, 2, 3);
 
             // With Exception
             log.METHODNAME(x, ""plain message"");
@@ -126,6 +132,9 @@ namespace Code
             log.Log(LogLevel.LOGLEVEL, x, ""{0}"", 0);
             log.Log(LogLevel.LOGLEVEL, x, ""{0} {1}"", 0, 1);
             log.Log(LogLevel.LOGLEVEL, x, ""{0} {1} {2}"", 0, 1, 2);
+            log.Log(LogLevel.LOGLEVEL, x, ""{One}"", 1);
+            log.Log(LogLevel.LOGLEVEL, x, ""{One} {Two}"", 1, 2);
+            log.Log(LogLevel.LOGLEVEL, x, ""{One} {Two} {Three}"", 1, 2, 3);
 
             // With Both
             log.METHODNAME(eventId, x, ""plain message"");
@@ -136,6 +145,9 @@ namespace Code
             log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0}"", 0);
             log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {1}"", 0, 1);
             log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {1} {2}"", 0, 1, 2);
+            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{One}"", 1);
+            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{One} {Two}"", 1, 2);
+            log.Log(LogLevel.LOGLEVEL, eventId, x, ""{One} {Two} {Three}"", 1, 2, 3);
         }
     }
 }
@@ -172,18 +184,22 @@ namespace Code
             // Basic method
             [|log.METHODNAME(""{0} {0}"", 0, 1)|];
             [|log.Log(LogLevel.LOGLEVEL, ""{0} {0}"", 0, 1)|];
+            [|log.Log(LogLevel.LOGLEVEL, ""{Repeated} {Repeated}"", 0)|];
 
             // With EventId
             [|log.METHODNAME(eventId, ""{0} {0}"", 0, 1)|];
             [|log.Log(LogLevel.LOGLEVEL, eventId, ""{0} {0}"", 0, 1)|];
+            [|log.Log(LogLevel.LOGLEVEL, eventId, ""{Repeated} {Repeated}"", 0)|];
 
             // With Exception
             [|log.METHODNAME(x, ""{0} {0}"", 0, 1)|];
             [|log.Log(LogLevel.LOGLEVEL, x, ""{0} {0}"", 0, 1)|];
+            [|log.Log(LogLevel.LOGLEVEL, x, ""{Repeated} {Repeated}"", 0)|];
 
             // With Both
             [|log.METHODNAME(eventId, x, ""{0} {0}"", 0, 1)|];
             [|log.Log(LogLevel.LOGLEVEL, eventId, x, ""{0} {0}"", 0, 1)|];
+            [|log.Log(LogLevel.LOGLEVEL, eventId, x, ""{Repeated} {Repeated}"", 0)|];
         }
     }
 }

--- a/src/Particular.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Particular.Analyzers/DiagnosticDescriptors.cs
@@ -195,5 +195,13 @@
             category: "Code",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor StructuredLoggingWithRepeatedToken = new DiagnosticDescriptor(
+            id: DiagnosticIds.StructuredLoggingWithRepeatedToken,
+            title: "Structured logging tokens cannot be repeated",
+            messageFormat: "A token '{0}' was repeated in a logging format string. While this works with string.Format(), it is known to break when using some structured logging libraries and so must be avoided.",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
     }
 }

--- a/src/Particular.Analyzers/DiagnosticIds.cs
+++ b/src/Particular.Analyzers/DiagnosticIds.cs
@@ -26,5 +26,6 @@
         public const string ImplicitCastFromDateTimeToDateTimeOffset = "PS0022";
         public const string NowUsedInsteadOfUtcNow = "PS0023";
         public const string NonInterfaceTypePrefixedWithI = "PS0024";
+        public const string StructuredLoggingWithRepeatedToken = "PS0025";
     }
 }

--- a/src/Particular.Analyzers/LoggingAnalyzer.cs
+++ b/src/Particular.Analyzers/LoggingAnalyzer.cs
@@ -1,0 +1,162 @@
+﻿namespace Particular.Analyzers
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Particular.Analyzers.Extensions;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class LoggingAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+            DiagnosticDescriptors.StructuredLoggingWithRepeatedToken);
+
+        static readonly ImmutableHashSet<string> wellKnownNsbLoggingMethodsWithFormat = new[]
+        {
+            "DebugFormat",
+            "InfoFormat",
+            "WarnFormat",
+            "ErrorFormat",
+            "FatalFormat",
+        }
+        .ToImmutableHashSet();
+
+        static readonly ImmutableHashSet<string> wellKnownMsLoggingMethodsWithFormat = new[]
+        {
+            "Log",
+            "LogTrace",
+            "LogDebug",
+            "LogInformation",
+            "LogWarning",
+            "LogError",
+            "LogCritical",
+        }
+        .ToImmutableHashSet();
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.InvocationExpression);
+        }
+
+        static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+        {
+            if (!(context.Node is InvocationExpressionSyntax invocation))
+            {
+                return;
+            }
+
+            if (!(invocation.Expression is MemberAccessExpressionSyntax memberAccess))
+            {
+                return;
+            }
+
+            if (!(memberAccess.Name is IdentifierNameSyntax identifierName))
+            {
+                return;
+            }
+
+            if (wellKnownNsbLoggingMethodsWithFormat.Contains(identifierName.Identifier.Text))
+            {
+                if (Analyze(context, invocation, "NServiceBus.Logging.ILog"))
+                {
+                    return;
+                }
+            }
+
+            if (wellKnownMsLoggingMethodsWithFormat.Contains(identifierName.Identifier.Text))
+            {
+                if (Analyze(context, invocation, "Microsoft.Extensions.Logging.ILogger"))
+                {
+                    return;
+                }
+            }
+        }
+
+        static bool Analyze(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationSyntax, string loggerFullName)
+        {
+            var loggerSymbol = context.SemanticModel.GetSymbolInfo(invocationSyntax, context.CancellationToken).Symbol;
+
+            if (!(loggerSymbol.GetMethodOrDefault() is IMethodSymbol method))
+            {
+                return false;
+            }
+
+            if (method.ReceiverType.ToString() != loggerFullName)
+            {
+                return false;
+            }
+
+            int formatIndex = -1;
+            int argsIndex = -1;
+
+            for (int i = 0; i < method.Parameters.Length; i++)
+            {
+                var p = method.Parameters[i];
+                if (formatIndex < 0)
+                {
+                    if (p.Name == "message" || p.Name == "format")
+                    {
+                        var typeString = p.Type.ToString();
+                        if (typeString == "string" || typeString == "string?")
+                        {
+                            formatIndex = i;
+                        }
+                    }
+                }
+                else if (argsIndex < 0)
+                {
+                    if (p.Type is IArrayTypeSymbol arrayType)
+                    {
+                        var elementType = arrayType.ElementType.ToString();
+                        if (elementType == "object" || elementType == "object?")
+                        {
+                            argsIndex = i;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (formatIndex < 0 || argsIndex < 0)
+            {
+                return false;
+            }
+
+            var argumentSyntaxes = invocationSyntax.ArgumentList.Arguments;
+
+            // Try to find the value of the format argument
+            if (formatIndex >= argumentSyntaxes.Count || !(argumentSyntaxes[formatIndex].Expression is LiteralExpressionSyntax literalExpression && literalExpression.IsKind(SyntaxKind.StringLiteralExpression)))
+            {
+                return false;
+            }
+
+            var formatString = literalExpression.ToString();
+            var argMatches = FormatExpressionArgumentRegex.Matches(formatString);
+            if (argMatches.Count <= 1)
+            {
+                return false;
+            }
+
+            var allKeys = argMatches.OfType<Match>().Select(m => m.Value).ToImmutableArray();
+            var uniqueKeyCount = allKeys.Distinct().Count();
+            if (uniqueKeyCount == argMatches.Count)
+            {
+                return false;
+            }
+
+            // Now find out which one (the first one, anyway) that's duplicated
+            var firstDupe = allKeys.GroupBy(key => key).OrderByDescending(g => g.Count()).First().Key;
+
+            context.ReportDiagnostic(DiagnosticDescriptors.StructuredLoggingWithRepeatedToken, invocationSyntax, firstDupe);
+            return true;
+        }
+
+        static readonly Regex FormatExpressionArgumentRegex = new Regex(@"\{\w\}", RegexOptions.Compiled);
+    }
+}

--- a/src/Particular.Analyzers/LoggingAnalyzer.cs
+++ b/src/Particular.Analyzers/LoggingAnalyzer.cs
@@ -157,6 +157,6 @@
             return true;
         }
 
-        static readonly Regex FormatExpressionArgumentRegex = new Regex(@"\{\w\}", RegexOptions.Compiled);
+        static readonly Regex FormatExpressionArgumentRegex = new Regex(@"\{\w+\}", RegexOptions.Compiled);
     }
 }


### PR DESCRIPTION
Disallows logging statements such as:

```csharp
logger.InfoFormat("{0} - {0}", value);
```

Targets parameterized logging methods on both the NServiceBus logger as well as a direct Microsoft.Extensions.Logging logger.

While repeating a formatting string key works just fine with `string.Format(…)` not all structured loggers allow this. NLog and the Microsoft.Extensions.Logging.Console implementation are known to throw exceptions in this circumstance.

This analyzer would have prevented the following issue from occurring:

- https://github.com/Particular/NServiceBus.Gateway/issues/529