### PR TITLE
New analyzers: Dictionary keys & async void + NUnit

### DIFF
--- a/src/Particular.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
@@ -6,8 +6,6 @@
 
     public class AsyncVoidAnalyzerTests : AnalyzerTestFixture<AsyncVoidAnalyzer>
     {
-
-
         [Test]
         public Task NoAsyncVoid()
         {

--- a/src/Particular.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/AsyncVoidAnalyzerTests.cs
@@ -1,0 +1,59 @@
+﻿namespace Particular.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Particular.Analyzers.Tests.Helpers;
+
+    public class AsyncVoidAnalyzerTests : AnalyzerTestFixture<AsyncVoidAnalyzer>
+    {
+
+
+        [Test]
+        public Task NoAsyncVoid()
+        {
+            var code = """
+                public class Foo
+                {
+                    async void [|Bad1|]() { await Task.Delay(1); }
+                    private async void [|Bad2|]() { await Task.Delay(1); }
+                    public async void [|Bad3|]() { await Task.Delay(1); }
+                    protected async void [|Bad4|]() { await Task.Delay(1); }
+                    static async void [|Bad5|]() { await Task.Delay(1); }
+                    static private async void [|Bad6|]() { await Task.Delay(1); }
+                    static public async void [|Bad7|]() { await Task.Delay(1); }
+                    static protected async void [|Bad8|]() { await Task.Delay(1); }
+                    async void [|Bad9|](string a, int b) { await Task.Delay(1); }
+
+                    async Task ReturnsTask1() { await Task.Delay(1); }
+                    private async Task ReturnsTask2() { await Task.Delay(1); }
+                    public async Task ReturnsTask3() { await Task.Delay(1); }
+                    protected async Task ReturnsTask4() { await Task.Delay(1); }
+                    static async Task ReturnsTask5() { await Task.Delay(1); }
+                    static private async Task ReturnsTask6() { await Task.Delay(1); }
+                    static public async Task ReturnsTask7() { await Task.Delay(1); }
+                    static protected async Task ReturnsTask8() { await Task.Delay(1); }
+                    async Task ReturnsTask9(string a, int b) { await Task.Delay(1); }
+
+                    async Task ReturnsValueTask1() { await Task.Delay(1); }
+                    private async Task ReturnsValueTask2() { await Task.Delay(1); }
+                    public async Task ReturnsValueTask3() { await Task.Delay(1); }
+                    protected async Task ReturnsValueTask4() { await Task.Delay(1); }
+                    static async Task ReturnsValueTask5() { await Task.Delay(1); }
+                    static private async Task ReturnsValueTask6() { await Task.Delay(1); }
+                    static public async Task ReturnsValueTask7() { await Task.Delay(1); }
+                    static protected async Task ReturnsValueTask8() { await Task.Delay(1); }
+                    async Task ReturnsValueTask9(string a, int b) { await Task.Delay(1); }
+
+                    public async Task RegularMethod()
+                    {
+                        async void [|Local|]() => await Task.Delay(1);
+
+                        await Task.Delay(1);
+                    }
+                }
+                """;
+
+            return Assert(code, DiagnosticIds.AsyncVoid);
+        }
+    }
+}

--- a/src/Particular.Analyzers.Tests/Cancellation/CancellationTryCatchAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/CancellationTryCatchAnalyzerTests.cs
@@ -2,16 +2,13 @@
 {
     using System.Linq;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class CancellationTryCatchAnalyzerTests : AnalyzerTestFixture<CancellationTryCatchAnalyzer>
     {
-        public CancellationTryCatchAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         public static readonly Data AllCatchBlocks;
         public static readonly Data CatchBlocksWithoutIdentifiers;
 
@@ -65,8 +62,8 @@
             CatchBlocksWithoutIdentifiers = catchBlocksWithoutIdentifiers.ToData();
         }
 
-        [Theory]
-        [MemberData(nameof(AllCatchBlocks))]
+        [Test]
+        [TestCaseSource(nameof(AllCatchBlocks))]
         public Task PassingSimpleToken(string expectedDiagnostic, string catchBlocks)
         {
             const string PassesSimpleTokenTemplate =
@@ -88,8 +85,8 @@
             return Assert(GetCode(PassesSimpleTokenTemplate, catchBlocks, "cancellationToken"), expectedDiagnostic);
         }
 
-        [Theory]
-        [MemberData(nameof(AllCatchBlocks))]
+        [Test]
+        [TestCaseSource(nameof(AllCatchBlocks))]
         public Task PassingTokenProperty(string expectedDiagnostic, string catchBlocks)
         {
             const string PassesTokenPropertyTemplate =
@@ -115,8 +112,8 @@ public class SomeContext
             return Assert(GetCode(PassesTokenPropertyTemplate, catchBlocks, "context.Token"), expectedDiagnostic);
         }
 
-        [Theory]
-        [MemberData(nameof(CatchBlocksWithoutIdentifiers))]
+        [Test]
+        [TestCaseSource(nameof(CatchBlocksWithoutIdentifiers))]
         public Task MethodThatGeneratesToken(string expectedDiagnostic, string catchBlocks)
         {
             const string PassesTokenPropertyTemplate =
@@ -139,8 +136,8 @@ public class SomeContext
             return Assert(GetCode(PassesTokenPropertyTemplate, catchBlocks, null), expectedDiagnostic);
         }
 
-        [Theory]
-        [MemberData(nameof(CatchBlocksWithoutIdentifiers))]
+        [Test]
+        [TestCaseSource(nameof(CatchBlocksWithoutIdentifiers))]
         public Task FuncThatGeneratesToken(string expectedDiagnostic, string catchBlocks)
         {
             const string PassesTokenPropertyTemplate =
@@ -164,8 +161,8 @@ public class SomeContext
             return Assert(GetCode(PassesTokenPropertyTemplate, catchBlocks, null), expectedDiagnostic);
         }
 
-        [Theory]
-        [MemberData(nameof(AllCatchBlocks))]
+        [Test]
+        [TestCaseSource(nameof(AllCatchBlocks))]
         public Task ThrowIfCancellationRequested(string expectedDiagnostic, string catchBlocks)
         {
             const string PassesSimpleTokenTemplate =
@@ -187,8 +184,8 @@ public class SomeContext
             return Assert(GetCode(PassesSimpleTokenTemplate, catchBlocks, "cancellationToken"), expectedDiagnostic);
         }
 
-        [Theory]
-        [MemberData(nameof(AllCatchBlocks))]
+        [Test]
+        [TestCaseSource(nameof(AllCatchBlocks))]
         public Task PassesCancellableContext(string expectedDiagnostic, string catchBlocks)
         {
             const string PassesCancellableContextTemplate =
@@ -215,8 +212,8 @@ class SomeContext : ICancellableContext { public CancellationToken CancellationT
             return Assert(GetCode(PassesCancellableContextTemplate, catchBlocks, "context.CancellationToken"), expectedDiagnostic);
         }
 
-        [Theory]
-        [MemberData(nameof(AllCatchBlocks))]
+        [Test]
+        [TestCaseSource(nameof(AllCatchBlocks))]
         public Task PassesTokenFromTokenSource(string expectedDiagnostic, string catchBlocks)
         {
             const string PassesCancellableContextTemplate =
@@ -242,8 +239,8 @@ class SomeContext : ICancellableContext { public CancellationToken CancellationT
             return Assert(GetCode(PassesCancellableContextTemplate, catchBlocks, "tokenSource.Token"), expectedDiagnostic);
         }
 
-        [Theory]
-        [MemberData(nameof(CatchBlocksWithoutIdentifiers))]
+        [Test]
+        [TestCaseSource(nameof(CatchBlocksWithoutIdentifiers))]
         public Task PassesNoTokenOrEmptyToken(string expectedDiagnostic, string catchBlocks)
         {
             const string PassesNoTokenOrEmptyTokenTemplate =
@@ -274,7 +271,7 @@ class SomeContext : ICancellableContext { public CancellationToken CancellationT
             return Assert(GetCode(PassesNoTokenOrEmptyTokenTemplate, noDiagnosticCatchBlocks, null), expectedDiagnostic);
         }
 
-        [Fact]
+        [Test]
         public Task NoWarnWhenSingleTokenUsedMultipleTimesInTry()
         {
             const string UsesSameTokenMultipleTimes =
@@ -309,10 +306,10 @@ class SomeContext : ICancellableContext { public CancellationToken CancellationT
             return Assert(UsesSameTokenMultipleTimes);
         }
 
-        [Theory]
-        [InlineData("newToken")]
-        [InlineData("tokenSource.Token")]
-        [InlineData("context.Token")]
+        [Test]
+        [TestCase("newToken")]
+        [TestCase("tokenSource.Token")]
+        [TestCase("context.Token")]
         public Task WarnWhenMultipleTokenUsedInTry(string tokenExpression)
         {
             const string UsesMultipleTokenTemplate =

--- a/src/Particular.Analyzers.Tests/Cancellation/ContextMethodParameterAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/ContextMethodParameterAnalyzerTests.cs
@@ -2,10 +2,9 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class ContextMethodParameterAnalyzerTests : AnalyzerTestFixture<ContextMethodParameterAnalyzer>
@@ -71,8 +70,6 @@ class MyClass : CancellableContext, IMyInterface
     static void MyMethod({0}) {{ }}
 }}";
 
-        public ContextMethodParameterAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         public static readonly Data SadParams = new List<string>
         {
             "CancellationToken [|foo|]",
@@ -85,62 +82,62 @@ class MyClass : CancellableContext, IMyInterface
             "object foo",
         }.ToData();
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadClasses(string @params) => Assert(GetCode(@class, @params), DiagnosticIds.CancellableContextMethodCancellationToken);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyClasses(string @params) => Assert(GetCode(@class, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadInterfaces(string @params) => Assert(GetCode(@interface, @params), DiagnosticIds.CancellableContextMethodCancellationToken);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyInterfaces(string @params) => Assert(GetCode(@interface, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadRecords(string @params) => Assert(GetCode(@record, @params), DiagnosticIds.CancellableContextMethodCancellationToken);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyRecords(string @params) => Assert(GetCode(@record, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadStructs(string @params) => Assert(GetCode(@struct, @params), DiagnosticIds.CancellableContextMethodCancellationToken);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyStructs(string @params) => Assert(GetCode(@struct, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadOverrides(string parameters) => Assert(GetCode(@override, parameters), DiagnosticIds.CancellableContextMethodCancellationToken);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyOverrides(string parameters) => Assert(GetCode(@override, parameters));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadExplicits(string parameters) => Assert(GetCode(@explicit, parameters), DiagnosticIds.CancellableContextMethodCancellationToken);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyExplicits(string parameters) => Assert(GetCode(@explicit, parameters));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyConstructors(string @params) => Assert(GetCode(constructor, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyStatics(string @params) => Assert(GetCode(@static, @params));
 
         static string GetCode(string template, string @params) => string.Format(template, @params);

--- a/src/Particular.Analyzers.Tests/Cancellation/DelegateParametersAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/DelegateParametersAnalyzerTests.cs
@@ -2,10 +2,9 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class DelegateParametersAnalyzerTests : AnalyzerTestFixture<DelegateParametersAnalyzer>
@@ -15,8 +14,6 @@
 {{
     delegate void MyDelegate({0});
 }}";
-
-        public DelegateParametersAnalyzerTests(ITestOutputHelper output) : base(output) { }
 
         public static readonly Data SadParams = new List<string>
         {
@@ -36,12 +33,12 @@
             "CancellationToken cancellationToken1, CancellationToken cancellationToken2, params object[] foos",
         }.ToData();
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task Sad(string @params) => Assert(GetCode(@params), DiagnosticIds.DelegateCancellationTokenMisplaced);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task Happy(string @params) => Assert(GetCode(@params));
 
         static string GetCode(string @params) => string.Format(@delegate, @params);

--- a/src/Particular.Analyzers.Tests/Cancellation/EmptyTokenAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/EmptyTokenAnalyzerTests.cs
@@ -2,10 +2,9 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class EmptyTokenAnalyzerTests : AnalyzerTestFixture<EmptyTokenAnalyzer>
@@ -16,8 +15,6 @@
     void MyMethod(CancellationToken cancellationToken) => Task.Delay(1, [|{0}|]);
 }}";
 
-        public EmptyTokenAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         public static readonly Data SadArgs = new List<(string, string)>
         {
             ("default", DiagnosticIds.EmptyCancellationTokenDefaultLiteral),
@@ -26,12 +23,12 @@
 
         public static readonly Data HappyArgs = new List<string> { "cancellationToken", "new CancellationToken()", "CancellationToken.None" }.ToData();
 
-        [Theory]
-        [MemberData(nameof(SadArgs))]
+        [Test]
+        [TestCaseSource(nameof(SadArgs))]
         public Task Sad(string arg, string diagnosticId) => Assert(GetCode(arg), diagnosticId);
 
-        [Theory]
-        [MemberData(nameof(HappyArgs))]
+        [Test]
+        [TestCaseSource(nameof(HappyArgs))]
         public Task Happy(string arg) => Assert(GetCode(arg));
 
         static string GetCode(string arg) => string.Format(invoke, arg);

--- a/src/Particular.Analyzers.Tests/Cancellation/MethodFuncParameterAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/MethodFuncParameterAnalyzerTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Particular.Analyzers.Tests.Cancellation
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using Particular.Analyzers.Cancellation;

--- a/src/Particular.Analyzers.Tests/Cancellation/MethodFuncParameterAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/MethodFuncParameterAnalyzerTests.cs
@@ -1,11 +1,12 @@
 ﻿namespace Particular.Analyzers.Tests.Cancellation
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class MethodFuncParameterAnalyzerTests : AnalyzerTestFixture<MethodFuncParameterAnalyzer>
@@ -54,8 +55,6 @@ class MyClass<T> : IMyInterface<T> where T : CancellableContext
     void IMyInterface<T>.MyMethod({0} foo) {{ }}
 }}";
 
-        public MethodFuncParameterAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         public static readonly Data SadNames = new List<(string, string[])>
         {
             ("Func<CancellableContext, CancellationToken, object>", new[] { DiagnosticIds.MethodFuncParameterMixedCancellation }),
@@ -86,7 +85,7 @@ class MyClass<T> : IMyInterface<T> where T : CancellableContext
 #endif
         }.ToData();
 
-        public static readonly Data HappyNames = new List<string>
+        public static readonly Data HappyNames = new string[]
         {
             "object",
             "Action",
@@ -106,39 +105,45 @@ class MyClass<T> : IMyInterface<T> where T : CancellableContext
             "Func<T, Task>",
         }.ToData();
 
-        [Theory]
-        [MemberData(nameof(SadNames))]
+        [Test]
+        [TestCaseSource(nameof(SadNames))]
         public Task SadMethods(string name, params string[] diagnosticIds) => Assert(GetCode(method, name), diagnosticIds);
 
-        [Theory]
-        [MemberData(nameof(HappyNames))]
+        [Test]
+        [TestCaseSource(nameof(HappyNames))]
         public Task HappyMethods(string name) => Assert(GetCode(method, name));
 
-        [Theory]
-        [MemberData(nameof(SadNames))]
+        [Test]
+        [TestCaseSource(nameof(SadNames))]
         public Task SadConstructors(string name, params string[] diagnosticIds) => Assert(GetCode(constructor, name), diagnosticIds);
 
-        [Theory]
-        [MemberData(nameof(HappyNames))]
+        [Test]
+        [TestCaseSource(nameof(HappyNames))]
         public Task HappyConstructors(string name) => Assert(GetCode(constructor, name));
 
-        [Theory]
-        [MemberData(nameof(SadNames))]
+        [Test]
+        [TestCaseSource(nameof(SadNames))]
         public Task SadDelegates(string name, params string[] diagnosticIds) => Assert(GetCode(@delegate, name), diagnosticIds);
 
-        [Theory]
-        [MemberData(nameof(HappyNames))]
+        [Test]
+        [TestCaseSource(nameof(HappyNames))]
         public Task HappyDelegates(string name) => Assert(GetCode(@delegate, name));
 
-        [Theory]
-        [MemberData(nameof(SadNames))]
-        [MemberData(nameof(HappyNames))]
-        public Task HappyOverrides(string name, params string[] diagnosticIds) => Assert(GetCode(@override, name), diagnosticIds);
+        [Test]
+        [TestCaseSource(nameof(HappyNames))]
+        public Task HappyOverrides(string name) => Assert(GetCode(@override, name));
 
-        [Theory]
-        [MemberData(nameof(SadNames))]
-        [MemberData(nameof(HappyNames))]
-        public Task HappyExplicits(string name, params string[] diagnosticIds) => Assert(GetCode(@explicit, name), diagnosticIds);
+        [Test]
+        [TestCaseSource(nameof(SadNames))]
+        public Task SadOverrides(string name, params string[] diagnosticIds) => Assert(GetCode(@override, name), diagnosticIds);
+
+        [Test]
+        [TestCaseSource(nameof(HappyNames))]
+        public Task HappyExplicits(string name) => Assert(GetCode(@explicit, name));
+
+        [Test]
+        [TestCaseSource(nameof(SadNames))]
+        public Task SadExplicits(string name, params string[] diagnosticIds) => Assert(GetCode(@explicit, name), diagnosticIds);
 
         static string GetCode(string template, string name) => string.Format(template, name);
     }

--- a/src/Particular.Analyzers.Tests/Cancellation/MethodParametersAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/MethodParametersAnalyzerTests.cs
@@ -2,10 +2,9 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class MethodParametersAnalyzerTests : AnalyzerTestFixture<MethodParametersAnalyzer>
@@ -54,8 +53,6 @@ class MyClass<T> : IMyInterface<T> where T : CancellableContext
     void IMyInterface<T>.MyMethod({0}) {{ }}
 }}";
 
-        public MethodParametersAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         public static readonly Data SadParams = new List<(string, string[])>
         {
             ("ICancellableContext foo, CancellationToken cancellationToken", new[] { DiagnosticIds.MethodMixedCancellation }),
@@ -92,39 +89,45 @@ class MyClass<T> : IMyInterface<T> where T : CancellableContext
             "T foo, object bar",
         }.ToData();
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadMethods(string @params, params string[] diagnosticIds) => Assert(GetCode(method, @params), diagnosticIds);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyMethods(string @params) => Assert(GetCode(method, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadConstructors(string @params, params string[] diagnosticIds) => Assert(GetCode(constructor, @params), diagnosticIds);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyConstructors(string @params) => Assert(GetCode(constructor, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadDelegates(string @params, params string[] diagnosticIds) => Assert(GetCode(@delegate, @params), diagnosticIds);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyDelegates(string @params) => Assert(GetCode(@delegate, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
-        [MemberData(nameof(HappyParams))]
-        public Task HappyOverrides(string @params, params string[] diagnosticIds) => Assert(GetCode(@override, @params), diagnosticIds);
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
+        public Task HappyOverrides(string @params) => Assert(GetCode(@override, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
-        [MemberData(nameof(HappyParams))]
-        public Task HappyExplicits(string @params, params string[] diagnosticIds) => Assert(GetCode(@explicit, @params), diagnosticIds);
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
+        public Task SadOverrides(string @params, params string[] diagnosticIds) => Assert(GetCode(@override, @params), diagnosticIds);
+
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
+        public Task HappyExplicits(string @params) => Assert(GetCode(@explicit, @params));
+
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
+        public Task SadExplicits(string @params, params string[] diagnosticIds) => Assert(GetCode(@explicit, @params), diagnosticIds);
 
         static string GetCode(string template, string @params) => string.Format(template, @params);
     }

--- a/src/Particular.Analyzers.Tests/Cancellation/MethodTokenNamesAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/MethodTokenNamesAnalyzerTests.cs
@@ -3,10 +3,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class MethodTokenNamesAnalyzerTests : AnalyzerTestFixture<MethodTokenNamesAnalyzer>
@@ -65,8 +64,6 @@ class MyClass : IMyInterface
 }}";
 #endif
 
-        public MethodTokenNamesAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         public static readonly Data SadPublicAndPrivateParams = new List<string>
         {
             "CancellationToken [|foo|], CancellationToken [|bar|]",
@@ -93,61 +90,61 @@ class MyClass : IMyInterface
             "object foo, CancellationToken fooCancellationToken, CancellationToken barCancellationToken",
         }.ToData();
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadMethods(string @params) => Assert(GetCode(method, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyMethods(string @params) => Assert(GetCode(method, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadConstructors(string @params) => Assert(GetCode(constructor, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyConstructors(string @params) => Assert(GetCode(constructor, @params));
 
-        [Theory]
-        [MemberData(nameof(SadPublicAndPrivateParams))]
+        [Test]
+        [TestCaseSource(nameof(SadPublicAndPrivateParams))]
         public Task SadOverrides(string @params) => Assert(GetCode(@override, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyOverrides(string @params) => Assert(GetCode(@override, @params));
 
-        [Theory]
-        [MemberData(nameof(SadPublicAndPrivateParams))]
+        [Test]
+        [TestCaseSource(nameof(SadPublicAndPrivateParams))]
         public Task SadExplicits(string @params) => Assert(GetCode(@explicit, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyExplicits(string @params) => Assert(GetCode(@explicit, @params));
 
-        [Theory]
-        [MemberData(nameof(SadParams))]
+        [Test]
+        [TestCaseSource(nameof(SadParams))]
         public Task SadDelegates(string @params) => Assert(GetCode(@delegate, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyDelegates(string @params) => Assert(GetCode(@delegate, @params));
 
-        [Theory]
-        [MemberData(nameof(SadPublicAndPrivateParams))]
+        [Test]
+        [TestCaseSource(nameof(SadPublicAndPrivateParams))]
         public Task SadInterfaceMethods(string @params) => Assert(GetCode(interfaceMethods, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyInterfaceMethods(string @params) => Assert(GetCode(interfaceMethods, @params));
 
 #if NET
-        [Theory]
-        [MemberData(nameof(SadPublicAndPrivateParams))]
+        [Test]
+        [TestCaseSource(nameof(SadPublicAndPrivateParams))]
         public Task SadInterfaceDefaultMethods(string @params) => Assert(GetCode(interfaceDefaultMethods, @params), DiagnosticIds.MethodCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyParams))]
+        [Test]
+        [TestCaseSource(nameof(HappyParams))]
         public Task HappyInterfaceDefaultMethods(string @params) => Assert(GetCode(interfaceDefaultMethods, @params));
 #endif
 

--- a/src/Particular.Analyzers.Tests/Cancellation/NonPrivateMethodTokenNameAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/NonPrivateMethodTokenNameAnalyzerTests.cs
@@ -3,10 +3,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class NonPrivateMethodTokenNameAnalyzerTests : AnalyzerTestFixture<NonPrivateMethodTokenNameAnalyzer>
@@ -65,8 +64,6 @@ class MyClass : IMyInterface
 }}";
 #endif
 
-        public NonPrivateMethodTokenNameAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         static readonly List<string> sadParams =
         [
             "CancellationToken [|token|]",
@@ -101,61 +98,61 @@ class MyClass : IMyInterface
             InterfacePrivateModifiers.SelectMany(modifiers => sadParams.Concat(happyParams).Select(param => (modifiers, param)))
             .Concat(InterfaceNonPrivateModifiers.SelectMany(modifiers => happyParams.Select(param => (modifiers, param)))).ToData();
 
-        [Theory]
-        [MemberData(nameof(SadData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
         public Task SadMethods(string modifiers, string @params) => Assert(GetCode(method, modifiers, @params), DiagnosticIds.NonPrivateMethodSingleCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyMethods(string modifiers, string @params) => Assert(GetCode(method, modifiers, @params));
 
-        [Theory]
-        [MemberData(nameof(SadData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
         public Task SadConstructors(string modifiers, string @params) => Assert(GetCode(constructor, modifiers, @params), DiagnosticIds.NonPrivateMethodSingleCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyConstructors(string modifiers, string @params) => Assert(GetCode(constructor, modifiers, @params));
 
-        [Theory]
-        [MemberData(nameof(SadData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
         public Task SadOverrides(string modifiers, string @params) => Assert(GetCode(@override, modifiers, @params), DiagnosticIds.NonPrivateMethodSingleCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyOverridesData))]
+        [Test]
+        [TestCaseSource(nameof(HappyOverridesData))]
         public Task HappyOverrides(string modifiers, string @params) => Assert(GetCode(@override, modifiers, @params));
 
-        [Theory]
-        [MemberData(nameof(SadInterfaceData))]
+        [Test]
+        [TestCaseSource(nameof(SadInterfaceData))]
         public Task SadExplicits(string modifiers, string @params) => Assert(GetCode(@explicit, modifiers, @params), DiagnosticIds.NonPrivateMethodSingleCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyInterfaceMethodData))]
+        [Test]
+        [TestCaseSource(nameof(HappyInterfaceMethodData))]
         public Task HappyExplicits(string modifiers, string @params) => Assert(GetCode(@explicit, modifiers, @params));
 
-        [Theory]
-        [MemberData(nameof(SadData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
         public Task SadDelegates(string modifiers, string @params) => Assert(GetCode(@delegate, modifiers, @params), DiagnosticIds.NonPrivateMethodSingleCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyDelegates(string modifiers, string @params) => Assert(GetCode(@delegate, modifiers, @params));
 
-        [Theory]
-        [MemberData(nameof(SadInterfaceData))]
+        [Test]
+        [TestCaseSource(nameof(SadInterfaceData))]
         public Task SadInterfaceMethods(string modifiers, string @params) => Assert(GetCode(interfaceMethods, modifiers, @params), DiagnosticIds.NonPrivateMethodSingleCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyInterfaceMethodData))]
+        [Test]
+        [TestCaseSource(nameof(HappyInterfaceMethodData))]
         public Task HappyInterfaceMethods(string modifiers, string @params) => Assert(GetCode(interfaceMethods, modifiers, @params));
 
 #if NET
-        [Theory]
-        [MemberData(nameof(SadInterfaceData))]
+        [Test]
+        [TestCaseSource(nameof(SadInterfaceData))]
         public Task SadInterfaceDefaultMethods(string modifiers, string @params) => Assert(GetCode(interfaceDefaultMethods, modifiers, @params), DiagnosticIds.NonPrivateMethodSingleCancellationTokenMisnamed);
 
-        [Theory]
-        [MemberData(nameof(HappyInterfaceDefaultMethodData))]
+        [Test]
+        [TestCaseSource(nameof(HappyInterfaceDefaultMethodData))]
         public Task HappyInterfaceDefaultMethods(string modifiers, string @params) => Assert(GetCode(interfaceDefaultMethods, modifiers, @params));
 #endif
 

--- a/src/Particular.Analyzers.Tests/Cancellation/TaskReturningMethodAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/TaskReturningMethodAnalyzerTests.cs
@@ -5,10 +5,9 @@
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class TaskReturningMethodAnalyzerTests : AnalyzerTestFixture<TaskReturningMethodAnalyzer>
@@ -122,8 +121,6 @@ class MyClass<T> where T : CancellableContext
             "T foo, object bar",
         ];
 
-        public TaskReturningMethodAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         public static readonly Data TestAttributes = new List<string>
         {
             "[NUnit.Framework.OneTimeSetUp]",
@@ -145,42 +142,42 @@ class MyClass<T> where T : CancellableContext
             .Concat(notTaskTypes.SelectMany(type => notTaskParams.Concat(taskParams).Select(@params => (type, @params))))
             .ToData();
 
-        [Theory]
-        [MemberData(nameof(SadData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
         public Task SadMethods(string returnType, string @params) => Assert(GetCode(method, returnType, @params), DiagnosticIds.TaskReturningMethodNoCancellation);
 
-        [Theory]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyMethods(string returnType, string @params) => Assert(GetCode(method, returnType, @params));
 
-        [Theory]
-        [MemberData(nameof(SadData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
         public Task SadDelegates(string returnType, string @params) => Assert(GetCode(@delegate, returnType, @params), DiagnosticIds.TaskReturningMethodNoCancellation);
 
-        [Theory]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyDelegates(string returnType, string @params) => Assert(GetCode(@delegate, returnType, @params));
 
-        [Theory]
-        [MemberData(nameof(SadData))]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyOverrides(string returnType, string @params) => Assert(GetCode(@override, returnType, @params));
 
-        [Theory]
-        [MemberData(nameof(SadData))]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyExplicits(string returnType, string @params) => Assert(GetCode(@explicit, returnType, @params));
 
-        [Theory]
-        [MemberData(nameof(SadData))]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyContexts(string returnType, string @params) => Assert(GetCode(context, returnType, @params));
 
-        [Theory]
-        [MemberData(nameof(TestAttributes))]
+        [Test]
+        [TestCaseSource(nameof(TestAttributes))]
         public Task HappyTests(string attribute) => Assert(GetTestCode(attribute, taskTypes.First(), notTaskParams.First()));
 
-        [Fact]
+        [Test]
         public Task HappyEntryPoint() => Assert(entryPoint, c => c.CompilationOptions = new CSharpCompilationOptions(OutputKind.ConsoleApplication));
 
         static string GetCode(string template, string returnType, string @params) => string.Format(template, returnType, @params);

--- a/src/Particular.Analyzers.Tests/Cancellation/TaskReturningMethodAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/TaskReturningMethodAnalyzerTests.cs
@@ -181,7 +181,7 @@ class MyClass<T> where T : CancellableContext
         public Task HappyTests(string attribute) => Assert(GetTestCode(attribute, taskTypes.First(), notTaskParams.First()));
 
         [Fact]
-        public Task HappyEntryPoint() => Assert(entryPoint, new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+        public Task HappyEntryPoint() => Assert(entryPoint, c => c.CompilationOptions = new CSharpCompilationOptions(OutputKind.ConsoleApplication));
 
         static string GetCode(string template, string returnType, string @params) => string.Format(template, returnType, @params);
 

--- a/src/Particular.Analyzers.Tests/Cancellation/TokenAccessibilityAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/TokenAccessibilityAnalyzerTests.cs
@@ -120,9 +120,12 @@ class MyClass : IMyInterface
         public Task HappyOverrides(string modifiers, string @params) => Assert(GetCode(@override, modifiers, @params));
 
         [Test]
-        [TestCaseSource(nameof(SadInterfaceMethodData))]
         [TestCaseSource(nameof(HappyInterfaceMethodData))]
-        public Task HappyExplicits(string modifiers, string @params, params string[] diagnosticIds) => Assert(RemoveMarkUp(GetCode(@explicit, modifiers, @params)), diagnosticIds);
+        public Task HappyExplicits(string modifiers, string @params) => Assert(RemoveMarkUp(GetCode(@explicit, modifiers, @params)));
+
+        [Test]
+        [TestCaseSource(nameof(SadInterfaceMethodData))]
+        public Task SadExplicits(string modifiers, string @params, string diagnosticId) => Assert(RemoveMarkUp(GetCode(@explicit, modifiers, @params)), diagnosticId);
 
         [Test]
         [TestCaseSource(nameof(SadData))]

--- a/src/Particular.Analyzers.Tests/Cancellation/TokenAccessibilityAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/Cancellation/TokenAccessibilityAnalyzerTests.cs
@@ -3,10 +3,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class TokenAccessibilityAnalyzerTests : AnalyzerTestFixture<TokenAccessibilityAnalyzer>
@@ -24,7 +23,7 @@
 }}
 
 class MyClass : MyBase
-{{    
+{{
     {0} override void MyMethod({1}) {{ }}
 }}";
 
@@ -76,8 +75,6 @@ class MyClass : IMyInterface
             "object foo, CancellationToken [|cancellationToken1|] = default, CancellationToken [|cancellationToken2|] = default, CancellationToken [|cancellationToken3|] = default",
         ];
 
-        public TokenAccessibilityAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         public static Data SadData =>
             PrivateModifiers.SelectMany(modifiers => nonPrivateParams.Select(param => (modifiers, param, DiagnosticIds.CancellationTokenPrivateOptional)))
             .Concat(NonPrivateModifiers.SelectMany(modifiers => privateParams.Select(param => (modifiers, param, DiagnosticIds.CancellationTokenNonPrivateRequired)))).ToData();
@@ -106,50 +103,50 @@ class MyClass : IMyInterface
             InterfacePrivateModifiers.SelectMany(modifiers => privateParams.Select(param => (modifiers, param)))
             .Concat(InterfaceNonPrivateModifiers.SelectMany(modifiers => nonPrivateParams.Select(param => (modifiers, param)))).ToData();
 
-        [Theory]
-        [MemberData(nameof(SadData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
         public Task SadMethods(string modifiers, string @params, string diagnosticId) => Assert(GetCode(method, modifiers, @params), diagnosticId);
 
-        [Theory]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyMethods(string modifiers, string @params) => Assert(GetCode(method, modifiers, @params));
 
-        [Theory]
-        [MemberData(nameof(SadOverridesData))]
+        [Test]
+        [TestCaseSource(nameof(SadOverridesData))]
         public Task SadOverrides(string modifiers, string @params, string diagnosticId) => Assert(GetCode(@override, modifiers, @params), diagnosticId);
 
-        [Theory]
-        [MemberData(nameof(HappyOverridesData))]
+        [Test]
+        [TestCaseSource(nameof(HappyOverridesData))]
         public Task HappyOverrides(string modifiers, string @params) => Assert(GetCode(@override, modifiers, @params));
 
-        [Theory]
-        [MemberData(nameof(SadInterfaceMethodData))]
-        [MemberData(nameof(HappyInterfaceMethodData))]
+        [Test]
+        [TestCaseSource(nameof(SadInterfaceMethodData))]
+        [TestCaseSource(nameof(HappyInterfaceMethodData))]
         public Task HappyExplicits(string modifiers, string @params, params string[] diagnosticIds) => Assert(RemoveMarkUp(GetCode(@explicit, modifiers, @params)), diagnosticIds);
 
-        [Theory]
-        [MemberData(nameof(SadData))]
+        [Test]
+        [TestCaseSource(nameof(SadData))]
         public Task SadDelegates(string modifiers, string @params, string diagnosticId) => Assert(GetCode(@delegate, modifiers, @params), diagnosticId);
 
-        [Theory]
-        [MemberData(nameof(HappyData))]
+        [Test]
+        [TestCaseSource(nameof(HappyData))]
         public Task HappyDelegates(string modifiers, string @params) => Assert(GetCode(@delegate, modifiers, @params));
 
-        [Theory]
-        [MemberData(nameof(SadInterfaceMethodData))]
+        [Test]
+        [TestCaseSource(nameof(SadInterfaceMethodData))]
         public Task SadInterfaceMethods(string modifiers, string @params, string diagnosticId) => Assert(GetCode(interfaceMethods, modifiers, @params), diagnosticId);
 
-        [Theory]
-        [MemberData(nameof(HappyInterfaceMethodData))]
+        [Test]
+        [TestCaseSource(nameof(HappyInterfaceMethodData))]
         public Task HappyInterfaceMethods(string modifiers, string @params) => Assert(GetCode(interfaceMethods, modifiers, @params));
 
 #if NET
-        [Theory]
-        [MemberData(nameof(SadInterfaceDefaultMethodData))]
+        [Test]
+        [TestCaseSource(nameof(SadInterfaceDefaultMethodData))]
         public Task SadInterfaceDefaultMethods(string modifiers, string @params, string diagnosticId) => Assert(GetCode(interfaceDefaultMethods, modifiers, @params), diagnosticId);
 
-        [Theory]
-        [MemberData(nameof(HappyInterfaceDefaultMethodData))]
+        [Test]
+        [TestCaseSource(nameof(HappyInterfaceDefaultMethodData))]
         public Task HappyInterfaceDefaultMethods(string modifiers, string @params) => Assert(GetCode(interfaceDefaultMethods, modifiers, @params));
 #endif
 

--- a/src/Particular.Analyzers.Tests/DateTimeImplicitCastAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DateTimeImplicitCastAnalyzerTests.cs
@@ -1,17 +1,14 @@
 ﻿namespace Particular.Analyzers.Tests
 {
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
 
     public class DateTimeImplicitCastAnalyzerTests
         : AnalyzerTestFixture<DateTimeImplicitCastAnalyzer>
     {
-        public DateTimeImplicitCastAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
-        [Fact]
+        [Test]
         public Task SimpleTest()
         {
             const string code = @"
@@ -46,7 +43,7 @@ public class Foo
             return Assert(code, "PS0022");
         }
 
-        [Fact]
+        [Test]
         public Task Tuples()
         {
             const string code = @"
@@ -63,7 +60,7 @@ public class Foo
             return Assert(code, "PS0022");
         }
 
-        [Fact]
+        [Test]
         public Task Indexer()
         {
             const string code = @"
@@ -89,7 +86,7 @@ public class HasIndexer
             return Assert(code, "PS0022");
         }
 
-        [Fact]
+        [Test]
         public Task MethodReturnValue()
         {
             const string code = @"
@@ -119,7 +116,7 @@ public class Foo
             return Assert(code, "PS0022");
         }
 
-        [Fact]
+        [Test]
         public Task MethodReturnValueAsync()
         {
             const string code = @"
@@ -156,7 +153,7 @@ public class Foo
             return Assert(code, "PS0022");
         }
 
-        [Fact]
+        [Test]
         public Task MethodParameter()
         {
             const string code = @"
@@ -190,7 +187,7 @@ public class Foo
             return Assert(code, "PS0022");
         }
 
-        [Fact]
+        [Test]
         public Task DelegateInvocation()
         {
             const string code = @"
@@ -230,7 +227,7 @@ public class Foo
             return Assert(code, "PS0022");
         }
 
-        [Fact]
+        [Test]
         public Task DontScrewUpOnParamsArrays()
         {
             const string code = @"
@@ -245,7 +242,7 @@ public class Foo
             return Assert(code, "PS0022");
         }
 
-        [Fact]
+        [Test]
         public Task DontFailOnRefAssignments()
         {
             // Because FastExpressionCompiler 4.0.0 caused a null-reference exception

--- a/src/Particular.Analyzers.Tests/DateTimeNowAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DateTimeNowAnalyzerTests.cs
@@ -1,16 +1,13 @@
 ﻿namespace Particular.Analyzers.Tests
 {
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Cancellation;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
 
     public class DateTimeNowAnalyzerTests : AnalyzerTestFixture<DateTimeNowAnalyzer>
     {
-        public DateTimeNowAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
-        [Fact]
+        [Test]
         public Task SimpleTest()
         {
             const string code = @"

--- a/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Particular.Analyzers.Tests
 {
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Threading.Tasks;
     using Particular.Analyzers.Tests.Helpers;
@@ -99,6 +100,9 @@
             return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType, config =>
             {
                 config
+#if NETFRAMEWORK
+                    .AddMetadataReferenceUsing<ISet<string>>()
+#endif
                     .AddMetadataReferenceUsing<ConcurrentDictionary<string, string>>()
                     .AddMetadataReferenceUsing<ImmutableDictionary<string, string>>();
             });

--- a/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
@@ -24,18 +24,35 @@
                     DICTIONARY_TYPE both = new DICTIONARY_TYPE();
                     var asVar = new DICTIONARY_TYPE();
                     DICTIONARY_TYPE asType = new();
+                    DICTIONARY_TYPE justVar;
 
                     return asType;
                 }
             }
 
             public class BadKey { }
+            public struct OkStruct { }
+            public interface IOkBecauseEquatable : IEquatable<IOkBecauseEquatable> { }
+
+            public class ClassWithMembers
+            {
+                public override bool Equals(object obj) => false;
+                public override int GetHashCode() => 42;
+
+                // Operators aren't sufficient, but are a "weird" method type that analyzer can't trip over
+                public static bool operator ==(ClassWithMembers a, ClassWithMembers b) => false;
+                public static bool operator !=(ClassWithMembers a, ClassWithMembers b) => true;
+            }
 
             public class InheritFromDictionary : DICTIONARY_TYPE { }
             """;
 
         [Theory]
         [InlineData("string")]
+        [InlineData("int")]
+        [InlineData("OkStruct")]
+        [InlineData("ClassWithMembers")]
+        [InlineData("IOkBecauseEquatable")]
         public Task Good(string keyType)
         {
             var dictionaryType = $"Dictionary<{keyType}, int>";
@@ -52,5 +69,25 @@
                 .Replace("DICTIONARY_TYPE", $"[|{dictionaryType}|]");
             return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
         }
+
+#if !NETFRAMEWORK
+        [Fact]
+        public Task RecordTypesOk()
+        {
+            var code = """
+                using System.Collections.Generic;
+
+                public class Foo
+                {
+                    public Dictionary<GoodRecord, int> Field;
+                    public Dictionary<GoodRecord, int> Property { get; set; }
+                }
+
+                public record class GoodRecord(string A, int B);
+                """;
+
+            return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
+        }
+#endif
     }
 }

--- a/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
@@ -1,0 +1,56 @@
+﻿namespace Particular.Analyzers.Tests
+{
+    using System.Threading.Tasks;
+    using Particular.Analyzers.Tests.Helpers;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class DictionaryKeysAnalyzerTests : AnalyzerTestFixture<DictionaryKeysAnalyzer>
+    {
+        public DictionaryKeysAnalyzerTests(ITestOutputHelper output) : base(output) { }
+
+        static readonly string template = """
+            using System.Collections.Generic;
+
+            public class Foo
+            {
+                public DICTIONARY_TYPE Field;
+                public DICTIONARY_TYPE Property { get; set; }
+                public DICTIONARY_TYPE[] FieldArray;
+                public DICTIONARY_TYPE[] PropertyArray { get; set; }
+
+                public DICTIONARY_TYPE ParamAndReturn(DICTIONARY_TYPE source)
+                {
+                    DICTIONARY_TYPE both = new DICTIONARY_TYPE();
+                    var asVar = new DICTIONARY_TYPE();
+                    DICTIONARY_TYPE asType = new();
+
+                    return asType;
+                }
+            }
+
+            public class BadKey { }
+
+            public class InheritFromDictionary : DICTIONARY_TYPE { }
+            """;
+
+        [Theory]
+        [InlineData("string")]
+        public Task Good(string keyType)
+        {
+            var dictionaryType = $"Dictionary<{keyType}, int>";
+            var code = template.Replace("DICTIONARY_TYPE", dictionaryType);
+            return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
+        }
+
+        [Theory]
+        [InlineData("BadKey")]
+        public Task Bad(string keyType)
+        {
+            var dictionaryType = $"Dictionary<{keyType}, int>";
+            var code = template.Replace("DICTIONARY_TYPE[]", $"[|{dictionaryType}[]|]")
+                .Replace("DICTIONARY_TYPE", $"[|{dictionaryType}|]");
+            return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
+        }
+    }
+}

--- a/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
@@ -104,7 +104,7 @@
             });
         }
 
-#if !NETFRAMEWORK
+#if NET
         [Test]
         public Task RecordTypesOk()
         {

--- a/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
@@ -1,17 +1,13 @@
 ﻿namespace Particular.Analyzers.Tests
 {
     using System.Collections.Concurrent;
-    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
 
     public class DictionaryKeysAnalyzerTests : AnalyzerTestFixture<DictionaryKeysAnalyzer>
     {
-        public DictionaryKeysAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
         static readonly string template = """
             using System.Collections.Generic;
 
@@ -50,12 +46,12 @@
             public class InheritFromDictionary : DICTIONARY_TYPE { }
             """;
 
-        [Theory]
-        [InlineData("string")]
-        [InlineData("int")]
-        [InlineData("OkStruct")]
-        [InlineData("ClassWithMembers")]
-        [InlineData("IOkBecauseEquatable")]
+        [Test]
+        [TestCase("string")]
+        [TestCase("int")]
+        [TestCase("OkStruct")]
+        [TestCase("ClassWithMembers")]
+        [TestCase("IOkBecauseEquatable")]
         public Task Good(string keyType)
         {
             var dictionaryType = $"Dictionary<{keyType}, int>";
@@ -63,8 +59,8 @@
             return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
         }
 
-        [Theory]
-        [InlineData("BadKey")]
+        [Test]
+        [TestCase("BadKey")]
         public Task Bad(string keyType)
         {
             var dictionaryType = $"Dictionary<{keyType}, int>";
@@ -73,14 +69,14 @@
             return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
         }
 
-        [Theory]
-        [InlineData("IDictionary<BadKey, int>")]
-        [InlineData("Dictionary<BadKey, int>")]
-        [InlineData("ConcurrentDictionary<BadKey, int>")]
-        [InlineData("HashSet<BadKey>")]
-        [InlineData("ISet<BadKey>")]
-        [InlineData("ImmutableHashSet<BadKey>")]
-        [InlineData("ImmutableDictionary<BadKey, int>")]
+        [Test]
+        [TestCase("IDictionary<BadKey, int>")]
+        [TestCase("Dictionary<BadKey, int>")]
+        [TestCase("ConcurrentDictionary<BadKey, int>")]
+        [TestCase("HashSet<BadKey>")]
+        [TestCase("ISet<BadKey>")]
+        [TestCase("ImmutableHashSet<BadKey>")]
+        [TestCase("ImmutableDictionary<BadKey, int>")]
         public Task CheckTypes(string type)
         {
             var code = $$"""
@@ -101,7 +97,7 @@
             {
                 config
 #if NETFRAMEWORK
-                    .AddMetadataReferenceUsing<ISet<string>>()
+                    .AddMetadataReferenceUsing<System.Collections.Generic.ISet<string>>()
 #endif
                     .AddMetadataReferenceUsing<ConcurrentDictionary<string, string>>()
                     .AddMetadataReferenceUsing<ImmutableDictionary<string, string>>();
@@ -109,7 +105,7 @@
         }
 
 #if !NETFRAMEWORK
-        [Fact]
+        [Test]
         public Task RecordTypesOk()
         {
             var code = """

--- a/src/Particular.Analyzers.Tests/DroppedTaskAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DroppedTaskAnalyzerTests.cs
@@ -2,9 +2,8 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class DroppedTaskAnalyzerTests : AnalyzerTestFixture<DroppedTaskAnalyzer>
@@ -98,14 +97,12 @@
             "void MyMethod() { var task = Task.Delay(0).ConfigureAwait(false); }",
         }.ToData();
 
-        public DroppedTaskAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
-        [Theory]
-        [MemberData(nameof(SadMethodData))]
+        [Test]
+        [TestCaseSource(nameof(SadMethodData))]
         public Task SadMethods(string method) => Assert(GetCode(method), DiagnosticIds.DroppedTask);
 
-        [Theory]
-        [MemberData(nameof(HappyMethodData))]
+        [Test]
+        [TestCaseSource(nameof(HappyMethodData))]
         public Task HappyMethods(string method) => Assert(GetCode(method));
 
         public static string GetCode(string method) => string.Format(code, method);

--- a/src/Particular.Analyzers.Tests/Helpers/AnalyzerTestFixture.cs
+++ b/src/Particular.Analyzers.Tests/Helpers/AnalyzerTestFixture.cs
@@ -91,7 +91,7 @@ using NServiceBus;
                 .Select(diagnostic => (diagnostic.Location.SourceSpan, diagnostic.Id))
                 .ToList();
 
-            NUnit.Framework.Assert.AreEqual(expectedSpansAndIds, actualSpansAndIds);
+            NUnit.Framework.Assert.That(actualSpansAndIds, Is.EqualTo(expectedSpansAndIds));
         }
 
         protected static void WriteCode(string code)

--- a/src/Particular.Analyzers.Tests/Helpers/TestCustomizations.cs
+++ b/src/Particular.Analyzers.Tests/Helpers/TestCustomizations.cs
@@ -1,0 +1,35 @@
+﻿namespace Particular.Analyzers.Tests.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft.CodeAnalysis;
+
+    public class TestCustomizations
+    {
+        HashSet<Type> typesForMetadataReferences = [
+            typeof(object),
+            typeof(Enumerable)
+        ];
+
+        public CompilationOptions CompilationOptions { get; set; }
+
+        public TestCustomizations AddMetadataReferenceUsing<T>()
+        {
+            typesForMetadataReferences.Add(typeof(T));
+            return this;
+        }
+
+        public IEnumerable<PortableExecutableReference> GetMetadataReferences()
+        {
+            var arr = typesForMetadataReferences
+                .Select(type => type.GetTypeInfo().Assembly)
+                .Distinct()
+                .Select(assembly => MetadataReference.CreateFromFile(assembly.Location))
+                .ToArray();
+
+            return arr;
+        }
+    }
+}

--- a/src/Particular.Analyzers.Tests/LoggingAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/LoggingAnalyzerTests.cs
@@ -2,20 +2,17 @@
 {
     using System;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
 
     public class LoggingAnalyzerTests : AnalyzerTestFixture<LoggingAnalyzer>
     {
-        public LoggingAnalyzerTests(ITestOutputHelper output) : base(output) { }
-
-        [Theory]
-        [InlineData("DebugFormat")]
-        [InlineData("InfoFormat")]
-        [InlineData("WarnFormat")]
-        [InlineData("ErrorFormat")]
-        [InlineData("FatalFormat")]
+        [Test]
+        [TestCase("DebugFormat")]
+        [TestCase("InfoFormat")]
+        [TestCase("WarnFormat")]
+        [TestCase("ErrorFormat")]
+        [TestCase("FatalFormat")]
         public Task NServiceBusLogging(string methodName)
         {
             var code = $$$""""
@@ -69,13 +66,13 @@
             return Assert(code, DiagnosticIds.StructuredLoggingWithRepeatedToken);
         }
 
-        [Theory]
-        [InlineData("LogDebug", "Debug")]
-        [InlineData("LogTrace", "Trace")]
-        [InlineData("LogInformation", "Information")]
-        [InlineData("LogWarning", "Warning")]
-        [InlineData("LogError", "Error")]
-        [InlineData("LogCritical", "Critical")]
+        [Test]
+        [TestCase("LogDebug", "Debug")]
+        [TestCase("LogTrace", "Trace")]
+        [TestCase("LogInformation", "Information")]
+        [TestCase("LogWarning", "Warning")]
+        [TestCase("LogError", "Error")]
+        [TestCase("LogCritical", "Critical")]
         public Task MicrosoftExtensionsLoggingAllOk(string methodName, string logLevel)
         {
             var code = $$"""
@@ -155,13 +152,13 @@
             return Assert(code, DiagnosticIds.StructuredLoggingWithRepeatedToken);
         }
 
-        [Theory]
-        [InlineData("LogDebug", "Debug")]
-        [InlineData("LogTrace", "Trace")]
-        [InlineData("LogInformation", "Information")]
-        [InlineData("LogWarning", "Warning")]
-        [InlineData("LogError", "Error")]
-        [InlineData("LogCritical", "Critical")]
+        [Test]
+        [TestCase("LogDebug", "Debug")]
+        [TestCase("LogTrace", "Trace")]
+        [TestCase("LogInformation", "Information")]
+        [TestCase("LogWarning", "Warning")]
+        [TestCase("LogError", "Error")]
+        [TestCase("LogCritical", "Critical")]
         public Task MicrosoftExtensionsLoggingNotOk(string methodName, string logLevel)
         {
             var code = $$"""

--- a/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
+++ b/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
@@ -13,8 +13,9 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <!--<PackageReference Include="NUnit.Analyzers" Version="4.0.1" />-->
   </ItemGroup>
 
 </Project>

--- a/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
+++ b/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <!--<PackageReference Include="NUnit.Analyzers" Version="4.0.1" />-->
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
+++ b/src/Particular.Analyzers.Tests/Particular.Analyzers.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
@@ -11,11 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Particular.Analyzers.Tests/TypeNameAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/TypeNameAnalyzerTests.cs
@@ -3,9 +3,8 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using NUnit.Framework;
     using Particular.Analyzers.Tests.Helpers;
-    using Xunit;
-    using Xunit.Abstractions;
     using Data = System.Collections.Generic.IEnumerable<object[]>;
 
     public class TypeNameAnalyzerTests : AnalyzerTestFixture<TypeNameAnalyzer>
@@ -13,8 +12,6 @@
         static readonly string @type = "{0} [|{1}|] {{ }}";
 
         static readonly string @delegate = "delegate void [|{0}|]();";
-
-        public TypeNameAnalyzerTests(ITestOutputHelper output) : base(output) { }
 
         static readonly List<string> interfaceKeywords =
         [
@@ -53,20 +50,20 @@
 
         public static Data HappyDelegatesData => nonInterfaceNames.ToData();
 
-        [Theory]
-        [MemberData(nameof(SadTypesData))]
+        [Test]
+        [TestCaseSource(nameof(SadTypesData))]
         public Task SadTypes(string keyword, string name) => Assert(GetTypeCode(@type, keyword, name), DiagnosticIds.NonInterfaceTypePrefixedWithI);
 
-        [Theory]
-        [MemberData(nameof(HappyTypesData))]
+        [Test]
+        [TestCaseSource(nameof(HappyTypesData))]
         public Task HappyTypes(string keyword, string name) => Assert(GetTypeCode(@type, keyword, name));
 
-        [Theory]
-        [MemberData(nameof(SadDelegatesData))]
+        [Test]
+        [TestCaseSource(nameof(SadDelegatesData))]
         public Task SadDelegates(string name) => Assert(GetDelegateCode(@delegate, name), DiagnosticIds.NonInterfaceTypePrefixedWithI);
 
-        [Theory]
-        [MemberData(nameof(HappyDelegatesData))]
+        [Test]
+        [TestCaseSource(nameof(HappyDelegatesData))]
         public Task HappyDelegates(string name) => Assert(GetDelegateCode(@delegate, name));
 
         static string GetTypeCode(string template, string keyword, string name) => string.Format(template, keyword, name);

--- a/src/Particular.Analyzers/AsyncVoidAnalyzer.cs
+++ b/src/Particular.Analyzers/AsyncVoidAnalyzer.cs
@@ -1,0 +1,45 @@
+﻿namespace Particular.Analyzers
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AsyncVoidAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.AsyncVoid);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.LocalFunctionStatement);
+        }
+
+        void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MethodDeclarationSyntax method)
+            {
+                Analyze(context, method.Identifier, method.ReturnType, method.Modifiers);
+            }
+            else if (context.Node is LocalFunctionStatementSyntax localFn)
+            {
+                Analyze(context, localFn.Identifier, localFn.ReturnType, localFn.Modifiers);
+            }
+        }
+
+        void Analyze(SyntaxNodeAnalysisContext context, SyntaxToken identifier, TypeSyntax returnType, SyntaxTokenList modifiers)
+        {
+            if (returnType?.ToString() == "void" && modifiers.Any(token => token.IsKind(SyntaxKind.AsyncKeyword)))
+            {
+                var diagnostic = Diagnostic.Create(DiagnosticDescriptors.AsyncVoid, identifier.GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/src/Particular.Analyzers/AsyncVoidAnalyzer.cs
+++ b/src/Particular.Analyzers/AsyncVoidAnalyzer.cs
@@ -33,7 +33,7 @@
             }
         }
 
-        void Analyze(SyntaxNodeAnalysisContext context, SyntaxToken identifier, TypeSyntax returnType, SyntaxTokenList modifiers)
+        static void Analyze(SyntaxNodeAnalysisContext context, SyntaxToken identifier, TypeSyntax returnType, SyntaxTokenList modifiers)
         {
             if (returnType?.ToString() == "void" && modifiers.Any(token => token.IsKind(SyntaxKind.AsyncKeyword)))
             {

--- a/src/Particular.Analyzers/Cancellation/CancellationTryCatchAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/CancellationTryCatchAnalyzer.cs
@@ -132,7 +132,7 @@
             return filterIdentifiers.Any();
         }
 
-        static string GetFirstCancellationTokenExpressionOrDefault(SyntaxNodeAnalysisContext context, TryStatementSyntax tryStatement)
+        static string? GetFirstCancellationTokenExpressionOrDefault(SyntaxNodeAnalysisContext context, TryStatementSyntax tryStatement)
         {
             // Because we are examining all descendants, this may result in false positives.
             // For example, a nested try block may contain cancellable invocations and
@@ -191,7 +191,7 @@
 
                         return null;
                     })
-                    .Where(expr => expr != null);
+                    .OfType<string>(); // removes nulls
 
                 foreach (var expr in argExpressions)
                 {

--- a/src/Particular.Analyzers/Cancellation/CancellationTryCatchAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/CancellationTryCatchAnalyzer.cs
@@ -29,7 +29,7 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is TryStatementSyntax tryStatement))
+            if (context.Node is not TryStatementSyntax tryStatement)
             {
                 return;
             }
@@ -45,7 +45,7 @@
                 return;
             }
 
-            if (!(GetFirstCancellationTokenExpressionOrDefault(context, tryStatement) is string cancellationTokenExpression))
+            if (GetFirstCancellationTokenExpressionOrDefault(context, tryStatement) is not string cancellationTokenExpression)
             {
                 return;
             }
@@ -85,7 +85,7 @@
                 return false;
             }
 
-            if (!(catchClause.Filter.FilterExpression is MemberAccessExpressionSyntax memberAccess) || !memberAccess.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+            if (catchClause.Filter.FilterExpression is not MemberAccessExpressionSyntax memberAccess || !memberAccess.IsKind(SyntaxKind.SimpleMemberAccessExpression))
             {
                 return false;
             }
@@ -172,8 +172,8 @@
                 }
 
                 var argExpressions = call.ArgumentList.Arguments
-                    .Where(arg => !(arg.Expression is LiteralExpressionSyntax))
-                    .Where(arg => !(arg.Expression is DefaultExpressionSyntax))
+                    .Where(arg => arg.Expression is not LiteralExpressionSyntax)
+                    .Where(arg => arg.Expression is not DefaultExpressionSyntax)
                     .Where(arg => !IsCancellationTokenNone(arg))
                     .Select(arg =>
                     {
@@ -209,21 +209,17 @@
             //   {
             //   }
             // assume "Exception" and "OperationCanceledException" refer to the System types
-            switch (catchType)
+            return catchType switch
             {
-                case null:
-                case "Exception":
-                    return ExceptionType;
-                case "OperationCanceledException":
-                    return OperationCanceledExceptionType;
-                default:
-                    return catchType;
-            }
+                null or "Exception" => ExceptionType,
+                "OperationCanceledException" => OperationCanceledExceptionType,
+                _ => catchType,
+            };
         }
 
         static bool IsCancellationTokenNone(ArgumentSyntax arg)
         {
-            if (!(arg.Expression is MemberAccessExpressionSyntax memberAccess))
+            if (arg.Expression is not MemberAccessExpressionSyntax memberAccess)
             {
                 return false;
             }
@@ -233,7 +229,7 @@
                 return false;
             }
 
-            if (!(memberAccess.Expression is SimpleNameSyntax @ref))
+            if (memberAccess.Expression is not SimpleNameSyntax @ref)
             {
                 return false;
             }

--- a/src/Particular.Analyzers/Cancellation/ContextMethodParameterAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/ContextMethodParameterAnalyzer.cs
@@ -27,7 +27,7 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is TypeDeclarationSyntax type))
+            if (context.Node is not TypeDeclarationSyntax type)
             {
                 return;
             }
@@ -52,7 +52,7 @@
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
 
-                if (!(member is IMethodSymbol method))
+                if (member is not IMethodSymbol method)
                 {
                     continue;
                 }

--- a/src/Particular.Analyzers/Cancellation/ContextMethodParameterAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/ContextMethodParameterAnalyzer.cs
@@ -38,7 +38,10 @@
                 return;
             }
 
-            Analyze(context, context.SemanticModel.GetDeclaredSymbol(type, context.CancellationToken));
+            if (context.SemanticModel.GetDeclaredSymbol(type, context.CancellationToken) is INamedTypeSymbol symbol)
+            {
+                Analyze(context, symbol);
+            }
         }
 
         static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol type)

--- a/src/Particular.Analyzers/Cancellation/DelegateParametersAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/DelegateParametersAnalyzer.cs
@@ -23,7 +23,7 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is DelegateDeclarationSyntax delegateSyntax))
+            if (context.Node is not DelegateDeclarationSyntax delegateSyntax)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/DelegateParametersAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/DelegateParametersAnalyzer.cs
@@ -39,7 +39,10 @@
                 return;
             }
 
-            Analyze(context, context.SemanticModel.GetInvokeMethod(delegateSyntax, context.CancellationToken, out _).Parameters);
+            if (context.SemanticModel.GetInvokeMethod(delegateSyntax, context.CancellationToken, out _) is IMethodSymbol method)
+            {
+                Analyze(context, method.Parameters);
+            }
         }
 
         static void Analyze(SyntaxNodeAnalysisContext context, ImmutableArray<IParameterSymbol> @params)

--- a/src/Particular.Analyzers/Cancellation/EmptyTokenAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/EmptyTokenAnalyzer.cs
@@ -23,7 +23,7 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is ArgumentSyntax arg))
+            if (context.Node is not ArgumentSyntax arg)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/MethodFuncParameterAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/MethodFuncParameterAnalyzer.cs
@@ -31,12 +31,12 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MemberDeclarationSyntax member))
+            if (context.Node is not MemberDeclarationSyntax member)
             {
                 return;
             }
 
-            if (!(context.SemanticModel.GetMethod(member, context.CancellationToken, out _) is IMethodSymbol method))
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out _) is not IMethodSymbol method)
             {
                 return;
             }
@@ -67,7 +67,7 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context, IParameterSymbol param)
         {
-            if (!(param.Type is INamedTypeSymbol type))
+            if (param.Type is not INamedTypeSymbol type)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/MethodParametersAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/MethodParametersAnalyzer.cs
@@ -30,12 +30,12 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MemberDeclarationSyntax member))
+            if (context.Node is not MemberDeclarationSyntax member)
             {
                 return;
             }
 
-            if (!(context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is IMethodSymbol method))
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/MethodParametersAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/MethodParametersAnalyzer.cs
@@ -3,8 +3,8 @@
     using System.Collections.Immutable;
     using System.Linq;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Particular.Analyzers.Extensions;
 
@@ -35,7 +35,7 @@
                 return;
             }
 
-            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method || declaredSymbol is null)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/MethodTokenNamesAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/MethodTokenNamesAnalyzer.cs
@@ -1,13 +1,13 @@
 ﻿namespace Particular.Analyzers.Cancellation
 {
+    using System;
     using System.Collections.Immutable;
     using System.Linq;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Particular.Analyzers.Extensions;
-    using System;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class MethodTokenNamesAnalyzer : DiagnosticAnalyzer
@@ -33,7 +33,7 @@
                 return;
             }
 
-            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method || declaredSymbol is null)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/MethodTokenNamesAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/MethodTokenNamesAnalyzer.cs
@@ -28,12 +28,12 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MemberDeclarationSyntax member))
+            if (context.Node is not MemberDeclarationSyntax member)
             {
                 return;
             }
 
-            if (!(context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is IMethodSymbol method))
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/NonPrivateMethodTokenNameAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/NonPrivateMethodTokenNameAnalyzer.cs
@@ -27,12 +27,12 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MemberDeclarationSyntax member))
+            if (context.Node is not MemberDeclarationSyntax member)
             {
                 return;
             }
 
-            if (!(context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is IMethodSymbol method))
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/NonPrivateMethodTokenNameAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/NonPrivateMethodTokenNameAnalyzer.cs
@@ -3,8 +3,8 @@
     using System.Collections.Immutable;
     using System.Linq;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Particular.Analyzers.Extensions;
 
@@ -32,7 +32,7 @@
                 return;
             }
 
-            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method || declaredSymbol is null)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/TaskReturningMethodAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/TaskReturningMethodAnalyzer.cs
@@ -26,12 +26,12 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MemberDeclarationSyntax member))
+            if (context.Node is not MemberDeclarationSyntax member)
             {
                 return;
             }
 
-            if (!(context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is IMethodSymbol method))
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/TaskReturningMethodAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/TaskReturningMethodAnalyzer.cs
@@ -3,8 +3,8 @@
     using System.Collections.Immutable;
     using System.Linq;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Particular.Analyzers.Extensions;
 
@@ -31,7 +31,7 @@
                 return;
             }
 
-            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method || declaredSymbol is null)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/TokenAccessibilityAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/TokenAccessibilityAnalyzer.cs
@@ -26,12 +26,12 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MemberDeclarationSyntax member))
+            if (context.Node is not MemberDeclarationSyntax member)
             {
                 return;
             }
 
-            if (!(context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is IMethodSymbol method))
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/TokenAccessibilityAnalyzer.cs
+++ b/src/Particular.Analyzers/Cancellation/TokenAccessibilityAnalyzer.cs
@@ -31,7 +31,7 @@
                 return;
             }
 
-            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method)
+            if (context.SemanticModel.GetMethod(member, context.CancellationToken, out var declaredSymbol) is not IMethodSymbol method || declaredSymbol is null)
             {
                 return;
             }

--- a/src/Particular.Analyzers/Cancellation/TokenParamUnusedSuppressor.cs
+++ b/src/Particular.Analyzers/Cancellation/TokenParamUnusedSuppressor.cs
@@ -27,13 +27,13 @@
                     continue;
                 }
 
-                if (!(node is ParameterSyntax parameter))
+                if (node is not ParameterSyntax parameter)
                 {
                     continue;
                 }
 
                 // cheapest checks first
-                if (!(parameter.Type is NameSyntax))
+                if (parameter.Type is not NameSyntax)
                 {
                     return;
                 }

--- a/src/Particular.Analyzers/Cancellation/TokenParamUnusedSuppressor.cs
+++ b/src/Particular.Analyzers/Cancellation/TokenParamUnusedSuppressor.cs
@@ -20,8 +20,13 @@
         {
             foreach (var diagnostic in context.ReportedDiagnostics)
             {
-                var node = diagnostic.Location.SourceTree.GetRoot(context.CancellationToken).FindNode(diagnostic.Location.SourceSpan);
+                var sourceTree = diagnostic.Location.SourceTree;
+                if (sourceTree is null)
+                {
+                    continue;
+                }
 
+                var node = sourceTree.GetRoot(context.CancellationToken).FindNode(diagnostic.Location.SourceSpan);
                 if (node == null)
                 {
                     continue;

--- a/src/Particular.Analyzers/DateTimeImplicitCastAnalyzer.cs
+++ b/src/Particular.Analyzers/DateTimeImplicitCastAnalyzer.cs
@@ -26,7 +26,7 @@
 
         static void AnalyzeVariableDeclaration(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is VariableDeclarationSyntax declaration))
+            if (context.Node is not VariableDeclarationSyntax declaration)
             {
                 return;
             }
@@ -57,19 +57,19 @@
 
         static void AnalyzeAssignment(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is AssignmentExpressionSyntax assignment))
+            if (context.Node is not AssignmentExpressionSyntax assignment)
             {
                 return;
             }
 
-            if (!(context.SemanticModel.GetTypeInfo(assignment.Left, context.CancellationToken).Type is INamedTypeSymbol leftType))
+            if (context.SemanticModel.GetTypeInfo(assignment.Left, context.CancellationToken).Type is not INamedTypeSymbol leftType)
             {
                 return;
             }
 
             if (leftType.IsTupleType && leftType.TypeArguments.Any(t => t.ToString() == "System.DateTimeOffset"))
             {
-                if (!(context.SemanticModel.GetTypeInfo(assignment.Right, context.CancellationToken).Type is INamedTypeSymbol rightType))
+                if (context.SemanticModel.GetTypeInfo(assignment.Right, context.CancellationToken).Type is not INamedTypeSymbol rightType)
                 {
                     return;
                 }
@@ -112,14 +112,14 @@
 
         static void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MethodDeclarationSyntax method))
+            if (context.Node is not MethodDeclarationSyntax method)
             {
                 return;
             }
 
             var returnType = method.ReturnType.ToString();
 
-            if (returnType != "DateTimeOffset" && returnType != "Task<DateTimeOffset>")
+            if (returnType is not "DateTimeOffset" and not "Task<DateTimeOffset>")
             {
                 return;
             }
@@ -139,7 +139,7 @@
 
         static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is InvocationExpressionSyntax invocation))
+            if (context.Node is not InvocationExpressionSyntax invocation)
             {
                 return;
             }
@@ -149,7 +149,7 @@
                 return;
             }
 
-            if (!(context.SemanticModel.GetSymbolInfo(invocation.Expression, context.CancellationToken).Symbol?.GetMethodOrDefault() is IMethodSymbol method))
+            if (context.SemanticModel.GetSymbolInfo(invocation.Expression, context.CancellationToken).Symbol?.GetMethodOrDefault() is not IMethodSymbol method)
             {
                 return;
             }

--- a/src/Particular.Analyzers/DateTimeNowAnalyzer.cs
+++ b/src/Particular.Analyzers/DateTimeNowAnalyzer.cs
@@ -22,7 +22,7 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MemberAccessExpressionSyntax memberAccess))
+            if (context.Node is not MemberAccessExpressionSyntax memberAccess)
             {
                 return;
             }
@@ -32,14 +32,14 @@
                 return;
             }
 
-            if (!(memberAccess.Expression is IdentifierNameSyntax identifier))
+            if (memberAccess.Expression is not IdentifierNameSyntax identifier)
             {
                 return;
             }
 
             var value = identifier?.Identifier.ValueText;
 
-            if (value == "DateTime" || value == "DateTimeOffset")
+            if (value is "DateTime" or "DateTimeOffset")
             {
                 context.ReportDiagnostic(DiagnosticDescriptors.NowUsedInsteadOfUtcNow, memberAccess, value);
             }

--- a/src/Particular.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Particular.Analyzers/DiagnosticDescriptors.cs
@@ -199,7 +199,7 @@
         public static readonly DiagnosticDescriptor DictionaryHasUnsupportedKeyType = new(
             id: DiagnosticIds.DictionaryHasUnsupportedKeyType,
             title: "Dictionary keys should implement IEquatable<T>",
-            messageFormat: "This {0} uses the type {1} as its key, which is a reference type that does not implement IEquatable<T>, which means that every object added to the collection will be evaluated using reference equality (object.Equals()) to be unique. This is often (but not always) a mistake, especially when used as a cache, because every lookup will be a cache miss. Don't blindly suppress this diagnostic or change this code. Be sure to consider whether the collection is really meant to evaluate equality using default reference equality, or if doing so will cause unintended side effects from objects that have the same data appearing to be duplicated.",
+            messageFormat: "This {0} uses the type {1} as its key, which is a reference type that does not implement IEquatable<T>, which means that every object added to the collection will be evaluated using reference equality (object.Equals()) to be unique. This is often (but not always) a mistake, especially when used as a cache, because every lookup will be a cache miss. Before suppressing this diagnostic or changing the code, be sure to consider whether the collection is really meant to evaluate equality using default reference equality, or if doing so will cause unintended side effects from objects that have the same data appearing to be duplicated.",
             category: "Code",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/src/Particular.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Particular.Analyzers/DiagnosticDescriptors.cs
@@ -206,8 +206,8 @@
 
         public static readonly DiagnosticDescriptor DictionaryHasUnsupportedKeyType = new DiagnosticDescriptor(
             id: DiagnosticIds.DictionaryHasUnsupportedKeyType,
-            title: "Dictionary keys must implement GetHashCode",
-            messageFormat: "Temp",
+            title: "Dictionary keys should implement GetHashCode",
+            messageFormat: "This {0} uses the type {1} as its key, which is a reference type that does not implement IEquatable<T>, which means that every object added to the collection will be evaluated using reference equality (object.Equals()) to be unique. This is often (but not always) a mistake, especially when used as a cache, because every lookup will be a cache miss.",
             category: "Code",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/src/Particular.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Particular.Analyzers/DiagnosticDescriptors.cs
@@ -206,7 +206,7 @@
 
         public static readonly DiagnosticDescriptor DictionaryHasUnsupportedKeyType = new DiagnosticDescriptor(
             id: DiagnosticIds.DictionaryHasUnsupportedKeyType,
-            title: "Dictionary keys should implement GetHashCode",
+            title: "Dictionary keys should implement IEquatable<T>",
             messageFormat: "This {0} uses the type {1} as its key, which is a reference type that does not implement IEquatable<T>, which means that every object added to the collection will be evaluated using reference equality (object.Equals()) to be unique. This is often (but not always) a mistake, especially when used as a cache, because every lookup will be a cache miss.",
             category: "Code",
             defaultSeverity: DiagnosticSeverity.Error,

--- a/src/Particular.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Particular.Analyzers/DiagnosticDescriptors.cs
@@ -4,7 +4,7 @@
 
     public static class DiagnosticDescriptors
     {
-        public static readonly DiagnosticDescriptor DroppedTask = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor DroppedTask = new(
             id: DiagnosticIds.DroppedTask,
             title: "Tasks returned from expressions should be returned, awaited, or assigned to a variable",
             messageFormat: "Return, await, or assign the task to a variable",
@@ -12,7 +12,7 @@
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor CancellableContextMethodCancellationToken = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor CancellableContextMethodCancellationToken = new(
             id: DiagnosticIds.CancellableContextMethodCancellationToken,
             title: "Instance methods on types implementing ICancellableContext should not have a CancellationToken parameter",
             messageFormat: "Remove the CancellationToken parameter",
@@ -20,7 +20,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor CancellationTokenNonPrivateRequired = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor CancellationTokenNonPrivateRequired = new(
             id: DiagnosticIds.CancellationTokenNonPrivateRequired,
             title: "A parameter of type CancellationToken on a non-private delegate or method should be optional",
             messageFormat: "Make the CancellationToken parameter optional",
@@ -28,7 +28,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor CancellationTokenPrivateOptional = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor CancellationTokenPrivateOptional = new(
             id: DiagnosticIds.CancellationTokenPrivateOptional,
             title: "A parameter of type CancellationToken on a private delegate or method should be required",
             messageFormat: "Make the CancellationToken parameter required",
@@ -36,7 +36,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor DelegateCancellationTokenMisplaced = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor DelegateCancellationTokenMisplaced = new(
             id: DiagnosticIds.DelegateCancellationTokenMisplaced,
             title: "Delegate CancellationToken parameters should come last",
             messageFormat: "Move the CancellationToken parameter to end of the parameter list",
@@ -44,7 +44,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor EmptyCancellationTokenDefaultLiteral = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor EmptyCancellationTokenDefaultLiteral = new(
             id: DiagnosticIds.EmptyCancellationTokenDefaultLiteral,
             title: "The default literal should not be used as an argument instead of CancellationToken.None",
             messageFormat: "Change the argument to CancellationToken.None",
@@ -52,7 +52,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor EmptyCancellationTokenDefaultOperator = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor EmptyCancellationTokenDefaultOperator = new(
             id: DiagnosticIds.EmptyCancellationTokenDefaultOperator,
             title: "The default operator should not be used as an argument instead of CancellationToken.None",
             messageFormat: "Change the argument to CancellationToken.None",
@@ -60,71 +60,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor MethodFuncParameterCancellationTokenMisplaced = new DiagnosticDescriptor(
-            id: DiagnosticIds.MethodFuncParameterCancellationTokenMisplaced,
-            title: "Funcs used as method parameters should have CancellationToken parameter type arguments last",
-            messageFormat: "Move the CancellationToken parameter type arguments to end of the parameter type arguments list",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor MethodFuncParameterMixedCancellation = new DiagnosticDescriptor(
-            id: DiagnosticIds.MethodFuncParameterMixedCancellation,
-            title: "Funcs used as method parameters should not have both CancellationToken parameter type arguments and type arguments implementing ICancellableContext",
-            messageFormat: "Remove either the CancellationToken parameter type arguments or the parameter type arguments implementing ICancellableContext",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor MethodFuncParameterMultipleCancellableContexts = new DiagnosticDescriptor(
-            id: DiagnosticIds.MethodFuncParameterMultipleCancellableContexts,
-            title: "Funcs used as method parameters should have at most one parameter type argument implementing ICancellableContext",
-            messageFormat: "Remove the duplicate parameter type arguments implementing ICancellableContext",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor MethodFuncParameterMultipleCancellationTokens = new DiagnosticDescriptor(
-            id: DiagnosticIds.MethodFuncParameterMultipleCancellationTokens,
-            title: "Funcs used as method parameters should have at most one CancellationToken parameter type argument",
-            messageFormat: "Remove the duplicate CancellationToken parameter type arguments",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor MethodFuncParameterTaskReturnTypeNoCancellation = new DiagnosticDescriptor(
-            id: DiagnosticIds.MethodFuncParameterTaskReturnTypeNoCancellation,
-            title: "A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext",
-            messageFormat: "Add a CancellationToken parameter type argument",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor MethodMixedCancellation = new DiagnosticDescriptor(
-            id: DiagnosticIds.MethodMixedCancellation,
-            title: "Methods should not have both CancellationToken parameters and parameters implementing ICancellableContext",
-            messageFormat: "Remove either the CancellationToken parameters or the parameters implementing ICancellableContext",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor MethodMultipleCancellableContexts = new DiagnosticDescriptor(
-            id: DiagnosticIds.MethodMultipleCancellableContexts,
-            title: "Methods should have at most one parameter implementing ICancellableContext",
-            messageFormat: "Remove the duplicate parameters implementing ICancellableContext",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor MethodMultipleCancellationTokens = new DiagnosticDescriptor(
-            id: DiagnosticIds.MethodMultipleCancellationTokens,
-            title: "Methods should have at most one CancellationToken parameter",
-            messageFormat: "Remove the duplicate CancellationToken parameters",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor MethodCancellationTokenMisnamed = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MethodCancellationTokenMisnamed = new(
             id: DiagnosticIds.MethodCancellationTokenMisnamed,
             title: "CancellationToken parameters should be named cancellationToken or have names ending with CancellationToken",
             messageFormat: "Rename the CancellationToken parameter to cancellationToken or to end with CancellationToken",
@@ -132,7 +68,71 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor NonPrivateMethodSingleCancellationTokenMisnamed = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MethodFuncParameterCancellationTokenMisplaced = new(
+            id: DiagnosticIds.MethodFuncParameterCancellationTokenMisplaced,
+            title: "Funcs used as method parameters should have CancellationToken parameter type arguments last",
+            messageFormat: "Move the CancellationToken parameter type arguments to end of the parameter type arguments list",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MethodFuncParameterMixedCancellation = new(
+            id: DiagnosticIds.MethodFuncParameterMixedCancellation,
+            title: "Funcs used as method parameters should not have both CancellationToken parameter type arguments and type arguments implementing ICancellableContext",
+            messageFormat: "Remove either the CancellationToken parameter type arguments or the parameter type arguments implementing ICancellableContext",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MethodFuncParameterMultipleCancellableContexts = new(
+            id: DiagnosticIds.MethodFuncParameterMultipleCancellableContexts,
+            title: "Funcs used as method parameters should have at most one parameter type argument implementing ICancellableContext",
+            messageFormat: "Remove the duplicate parameter type arguments implementing ICancellableContext",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MethodFuncParameterMultipleCancellationTokens = new(
+            id: DiagnosticIds.MethodFuncParameterMultipleCancellationTokens,
+            title: "Funcs used as method parameters should have at most one CancellationToken parameter type argument",
+            messageFormat: "Remove the duplicate CancellationToken parameter type arguments",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MethodFuncParameterTaskReturnTypeNoCancellation = new(
+            id: DiagnosticIds.MethodFuncParameterTaskReturnTypeNoCancellation,
+            title: "A Func used as a method parameter with a Task, ValueTask, or ValueTask<T> return type argument should have at least one CancellationToken parameter type argument unless it has a parameter type argument implementing ICancellableContext",
+            messageFormat: "Add a CancellationToken parameter type argument",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MethodMixedCancellation = new(
+            id: DiagnosticIds.MethodMixedCancellation,
+            title: "Methods should not have both CancellationToken parameters and parameters implementing ICancellableContext",
+            messageFormat: "Remove either the CancellationToken parameters or the parameters implementing ICancellableContext",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MethodMultipleCancellableContexts = new(
+            id: DiagnosticIds.MethodMultipleCancellableContexts,
+            title: "Methods should have at most one parameter implementing ICancellableContext",
+            messageFormat: "Remove the duplicate parameters implementing ICancellableContext",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor MethodMultipleCancellationTokens = new(
+            id: DiagnosticIds.MethodMultipleCancellationTokens,
+            title: "Methods should have at most one CancellationToken parameter",
+            messageFormat: "Remove the duplicate CancellationToken parameters",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor NonPrivateMethodSingleCancellationTokenMisnamed = new(
             id: DiagnosticIds.NonPrivateMethodSingleCancellationTokenMisnamed,
             title: "Single, non-private CancellationToken parameters should be named cancellationToken",
             messageFormat: "Rename the CancellationToken parameter to cancellationToken",
@@ -140,7 +140,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor TaskReturningMethodNoCancellation = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor TaskReturningMethodNoCancellation = new(
             id: DiagnosticIds.TaskReturningMethodNoCancellation,
             title: "A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext",
             messageFormat: "Add a CancellationToken parameter",
@@ -148,7 +148,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor ImproperTryCatchSystemException = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor ImproperTryCatchSystemException = new(
             id: DiagnosticIds.ImproperTryCatchSystemException,
             title: "When catching System.Exception, cancellation needs to be properly accounted for",
             messageFormat: "When a try block involves possible cancellation, catching Exception should be preceded by catching OperationCanceledException, or filtered by exception type and cancellationToken.IsCancellationRequested. See https://go.particular.net/exception-handling-with-cancellation.",
@@ -156,7 +156,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor ImproperTryCatchOperationCanceled = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor ImproperTryCatchOperationCanceled = new(
             id: DiagnosticIds.ImproperTryCatchOperationCanceled,
             title: "When catching OperationCanceledException, cancellation needs to be properly accounted for",
             messageFormat: "Catching OperationCanceledException should be filtered by cancellationToken.IsCancellationRequested. See https://go.particular.net/exception-handling-with-cancellation.",
@@ -164,7 +164,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor MultipleCancellationTokensInATry = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor MultipleCancellationTokensInATry = new(
             id: DiagnosticIds.MultipleCancellationTokensInATry,
             title: "Highlight when a try block passes multiple cancellation tokens",
             messageFormat: "This try block passes more than one CancellationToken (or ICancellableContext) to other methods, which can be confusing. Suppress this message with a #pragma, add a comment explaining the use of the two tokens, and ensure any CancellationToken used in a catch block is the correct one.",
@@ -172,7 +172,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor ImplicitCastFromDateTimeToDateTimeOffset = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor ImplicitCastFromDateTimeToDateTimeOffset = new(
             id: DiagnosticIds.ImplicitCastFromDateTimeToDateTimeOffset,
             title: "A DateTime should not be implicitly cast to a DateTimeOffset",
             messageFormat: "Do not implicitly cast a DateTime to a DateTimeOffset",
@@ -180,7 +180,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor NowUsedInsteadOfUtcNow = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor NowUsedInsteadOfUtcNow = new(
             id: DiagnosticIds.NowUsedInsteadOfUtcNow,
             title: "DateTime.UtcNow or DateTimeOffset.UtcNow should be used instead of DateTime.Now and DateTimeOffset.Now, unless the value is being used for displaying the current date-time in a user's local time zone",
             messageFormat: "Use {0}.UtcNow instead of {0}.Now",
@@ -188,7 +188,7 @@
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor NonInterfaceTypePrefixedWithI = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor NonInterfaceTypePrefixedWithI = new(
             id: DiagnosticIds.NonInterfaceTypePrefixedWithI,
             title: "A non-interface type should not be prefixed with I",
             messageFormat: "Remove the I prefix from {0}",
@@ -196,15 +196,7 @@
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor StructuredLoggingWithRepeatedToken = new DiagnosticDescriptor(
-            id: DiagnosticIds.StructuredLoggingWithRepeatedToken,
-            title: "Structured logging tokens cannot be repeated",
-            messageFormat: "A token '{0}' was repeated in a logging format string. While this works with string.Format(), it is known to break when using some structured logging libraries and so must be avoided.",
-            category: "Code",
-            defaultSeverity: DiagnosticSeverity.Warning,
-            isEnabledByDefault: true);
-
-        public static readonly DiagnosticDescriptor DictionaryHasUnsupportedKeyType = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor DictionaryHasUnsupportedKeyType = new(
             id: DiagnosticIds.DictionaryHasUnsupportedKeyType,
             title: "Dictionary keys should implement IEquatable<T>",
             messageFormat: "This {0} uses the type {1} as its key, which is a reference type that does not implement IEquatable<T>, which means that every object added to the collection will be evaluated using reference equality (object.Equals()) to be unique. This is often (but not always) a mistake, especially when used as a cache, because every lookup will be a cache miss.",
@@ -212,7 +204,15 @@
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
-        public static readonly DiagnosticDescriptor AsyncVoid = new DiagnosticDescriptor(
+        public static readonly DiagnosticDescriptor StructuredLoggingWithRepeatedToken = new(
+            id: DiagnosticIds.StructuredLoggingWithRepeatedToken,
+            title: "Structured logging tokens cannot be repeated",
+            messageFormat: "A token '{0}' was repeated in a logging format string. While this works with string.Format(), it is known to break when using some structured logging libraries and so must be avoided.",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor AsyncVoid = new(
             id: DiagnosticIds.AsyncVoid,
             title: "Methods should not be declared async void",
             messageFormat: "An `async void` method is almost always a mistake as nothing can be returned to await. Should only be used for event delegates, in which case this rule should be disabled in that instance.",

--- a/src/Particular.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Particular.Analyzers/DiagnosticDescriptors.cs
@@ -211,5 +211,13 @@
             category: "Code",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor AsyncVoid = new DiagnosticDescriptor(
+            id: DiagnosticIds.AsyncVoid,
+            title: "Methods should not be declared async void",
+            messageFormat: "An `async void` method is almost always a mistake as nothing can be returned to await. Should only be used for event delegates, in which case this rule should be disabled in that instance.",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
     }
 }

--- a/src/Particular.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Particular.Analyzers/DiagnosticDescriptors.cs
@@ -199,7 +199,7 @@
         public static readonly DiagnosticDescriptor DictionaryHasUnsupportedKeyType = new(
             id: DiagnosticIds.DictionaryHasUnsupportedKeyType,
             title: "Dictionary keys should implement IEquatable<T>",
-            messageFormat: "This {0} uses the type {1} as its key, which is a reference type that does not implement IEquatable<T>, which means that every object added to the collection will be evaluated using reference equality (object.Equals()) to be unique. This is often (but not always) a mistake, especially when used as a cache, because every lookup will be a cache miss.",
+            messageFormat: "This {0} uses the type {1} as its key, which is a reference type that does not implement IEquatable<T>, which means that every object added to the collection will be evaluated using reference equality (object.Equals()) to be unique. This is often (but not always) a mistake, especially when used as a cache, because every lookup will be a cache miss. Don't blindly suppress this diagnostic or change this code. Be sure to consider whether the collection is really meant to evaluate equality using default reference equality, or if doing so will cause unintended side effects from objects that have the same data appearing to be duplicated.",
             category: "Code",
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/src/Particular.Analyzers/DiagnosticDescriptors.cs
+++ b/src/Particular.Analyzers/DiagnosticDescriptors.cs
@@ -203,5 +203,13 @@
             category: "Code",
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor DictionaryHasUnsupportedKeyType = new DiagnosticDescriptor(
+            id: DiagnosticIds.DictionaryHasUnsupportedKeyType,
+            title: "Dictionary keys must implement GetHashCode",
+            messageFormat: "Temp",
+            category: "Code",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
     }
 }

--- a/src/Particular.Analyzers/DiagnosticIds.cs
+++ b/src/Particular.Analyzers/DiagnosticIds.cs
@@ -27,5 +27,6 @@
         public const string NowUsedInsteadOfUtcNow = "PS0023";
         public const string NonInterfaceTypePrefixedWithI = "PS0024";
         public const string StructuredLoggingWithRepeatedToken = "PS0025";
+        public const string DictionaryHasUnsupportedKeyType = "PS0025";
     }
 }

--- a/src/Particular.Analyzers/DiagnosticIds.cs
+++ b/src/Particular.Analyzers/DiagnosticIds.cs
@@ -26,7 +26,7 @@
         public const string ImplicitCastFromDateTimeToDateTimeOffset = "PS0022";
         public const string NowUsedInsteadOfUtcNow = "PS0023";
         public const string NonInterfaceTypePrefixedWithI = "PS0024";
-        public const string StructuredLoggingWithRepeatedToken = "PS0025";
         public const string DictionaryHasUnsupportedKeyType = "PS0025";
+        public const string StructuredLoggingWithRepeatedToken = "PS0026";
     }
 }

--- a/src/Particular.Analyzers/DiagnosticIds.cs
+++ b/src/Particular.Analyzers/DiagnosticIds.cs
@@ -28,5 +28,6 @@
         public const string NonInterfaceTypePrefixedWithI = "PS0024";
         public const string DictionaryHasUnsupportedKeyType = "PS0025";
         public const string StructuredLoggingWithRepeatedToken = "PS0026";
+        public const string AsyncVoid = "PS0027";
     }
 }

--- a/src/Particular.Analyzers/DictionaryKeysAnalyzer.cs
+++ b/src/Particular.Analyzers/DictionaryKeysAnalyzer.cs
@@ -1,0 +1,207 @@
+﻿namespace Particular.Analyzers
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DictionaryKeysAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.DictionaryHasUnsupportedKeyType);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(StartAnalysis);
+        }
+
+        void StartAnalysis(CompilationStartAnalysisContext context)
+        {
+            var knownTypes = new KnownTypes(context.Compilation);
+
+            context.RegisterSymbolAction(c => AnalyzeProperty(c, knownTypes), SymbolKind.Property);
+            context.RegisterSymbolAction(c => AnalyzeField(c, knownTypes), SymbolKind.Field);
+            context.RegisterSymbolAction(c => AnalyzeMethod(c, knownTypes), SymbolKind.Method);
+
+            context.RegisterSyntaxNodeAction(c => AnalyzeVariableDeclaration(c, knownTypes), SyntaxKind.LocalDeclarationStatement);
+            context.RegisterSyntaxNodeAction(c => AnalyzeClassDeclaration(c, knownTypes), SyntaxKind.ClassDeclaration);
+        }
+
+        void AnalyzeProperty(SymbolAnalysisContext context, KnownTypes knownTypes)
+        {
+            if (context.Symbol is IPropertySymbol prop)
+            {
+                AnalyzeType(knownTypes, prop.Type, GetNearest<PropertyDeclarationSyntax>(prop, context.CancellationToken).Type, context.ReportDiagnostic);
+            }
+        }
+
+        void AnalyzeField(SymbolAnalysisContext context, KnownTypes knownTypes)
+        {
+            if (context.Symbol is IFieldSymbol field)
+            {
+                AnalyzeType(knownTypes, field.Type, GetNearest<VariableDeclarationSyntax>(field, context.CancellationToken).Type, context.ReportDiagnostic);
+            }
+        }
+
+        void AnalyzeMethod(SymbolAnalysisContext context, KnownTypes knownTypes)
+        {
+            if (context.Symbol is IMethodSymbol method)
+            {
+                if (method.AssociatedSymbol is IPropertySymbol)
+                {
+                    // The getter of a property is tested as a property, not as a method
+                    return;
+                }
+
+                var methodSyntax = GetNearest<MethodDeclarationSyntax>(method, context.CancellationToken);
+
+                if (!method.ReturnsVoid)
+                {
+                    AnalyzeType(knownTypes, method.ReturnType, methodSyntax.ReturnType, context.ReportDiagnostic);
+                }
+
+                for (var i = 0; i < method.Parameters.Length; i++)
+                {
+                    var parameterType = method.Parameters[i].Type;
+                    var parameterSyntax = GetNearest<ParameterSyntax>(method.Parameters[i], context.CancellationToken).Type;
+                    AnalyzeType(knownTypes, parameterType, parameterSyntax, context.ReportDiagnostic);
+                }
+            }
+        }
+
+        void AnalyzeVariableDeclaration(SyntaxNodeAnalysisContext context, KnownTypes knownTypes)
+        {
+            if (context.Node is LocalDeclarationStatementSyntax vDec)
+            {
+                // Don't want to analyze "var"
+                if (vDec.Declaration.Type is GenericNameSyntax nameSyntax)
+                {
+                    var typeSymbol = context.SemanticModel.GetTypeInfo(vDec.Declaration.Type);
+                    AnalyzeType(knownTypes, typeSymbol.Type, nameSyntax, context.ReportDiagnostic);
+                }
+
+                foreach (var variable in vDec.Declaration.Variables)
+                {
+                    if (variable.Initializer.Value is ObjectCreationExpressionSyntax creationSyntax)
+                    {
+                        // Don't want to analyze "null" or another variable name or new()
+                        if (creationSyntax.Type != null)
+                        {
+                            if (context.SemanticModel.GetSymbolInfo(creationSyntax.Type, context.CancellationToken).Symbol is INamedTypeSymbol typeSymbol)
+                            {
+                                AnalyzeType(knownTypes, typeSymbol, creationSyntax.Type, context.ReportDiagnostic);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, KnownTypes knownTypes)
+        {
+            if (context.Node is ClassDeclarationSyntax classDec)
+            {
+                if (classDec.BaseList != null && context.SemanticModel.GetDeclaredSymbol(classDec, context.CancellationToken) is ITypeSymbol classType)
+                {
+                    foreach (var baseType in classDec.BaseList.Types)
+                    {
+                        var type = context.SemanticModel.GetTypeInfo(baseType.Type, context.CancellationToken).Type;
+                        if (type != null)
+                        {
+                            AnalyzeType(knownTypes, type, baseType, context.ReportDiagnostic);
+                        }
+                    }
+                }
+            }
+        }
+
+        TSyntaxType GetNearest<TSyntaxType>(ISymbol symbol, CancellationToken cancellationToken)
+            where TSyntaxType : SyntaxNode
+        {
+            if (symbol.DeclaringSyntaxReferences.Length == 0)
+            {
+                return null;
+            }
+
+            var firstReference = symbol.DeclaringSyntaxReferences[0];
+            var declaringSyntax = firstReference.GetSyntax(cancellationToken);
+            var syntax = declaringSyntax.FirstAncestorOrSelf<TSyntaxType>();
+            return syntax;
+        }
+
+        void AnalyzeType(KnownTypes knownTypes, ITypeSymbol type, SyntaxNode syntax, Action<Diagnostic> reportDiagnostic)
+        {
+            if (type is IArrayTypeSymbol arrayType)
+            {
+                AnalyzeType(knownTypes, arrayType.ElementType, syntax, reportDiagnostic);
+                return;
+            }
+
+            if (type is INamedTypeSymbol namedType && namedType.IsGenericType && knownTypes.DictionaryTypes.Contains(namedType.ConstructedFrom, SymbolEqualityComparer.IncludeNullability))
+            {
+                var key = namedType.TypeArguments[0];
+
+                if (!IsAppropriateDictionaryKey(knownTypes, key))
+                {
+                    var diagnostic = Diagnostic.Create(DiagnosticDescriptors.DictionaryHasUnsupportedKeyType, syntax.GetLocation());
+                    reportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        static bool IsAppropriateDictionaryKey(KnownTypes knownTypes, ITypeSymbol type)
+        {
+            if (type.Equals(knownTypes.String, SymbolEqualityComparer.IncludeNullability) || type.IsValueType)
+            {
+                return true;
+            }
+
+            bool hasEquals = false;
+            bool hasGetHashCode = false;
+
+            foreach (var member in type.GetMembers())
+            {
+                hasEquals |= member.Name == "Equals" && member.IsOverride;
+                hasGetHashCode |= member.Name == "GetHashCode" && member.IsOverride;
+            }
+
+            return hasEquals && hasGetHashCode;
+        }
+
+        class KnownTypes
+        {
+            public ImmutableHashSet<INamedTypeSymbol> DictionaryTypes { get; }
+            public INamedTypeSymbol String { get; }
+
+            public KnownTypes(Compilation compilation)
+            {
+                var dictionaryTypes = new Type[]
+                {
+                    typeof(IDictionary<,>),
+                    typeof(Dictionary<,>),
+                    typeof(IReadOnlyDictionary<,>),
+                    typeof(ConcurrentDictionary<,>),
+                    typeof(HashSet<>),
+                    typeof(ISet<>),
+                    typeof(ImmutableHashSet<>),
+                    typeof(ImmutableDictionary<,>)
+                };
+
+                DictionaryTypes = dictionaryTypes
+                    .Select(t => compilation.GetTypeByMetadataName(t.FullName))
+                    .ToImmutableHashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+                String = compilation.GetSpecialType(SpecialType.System_String);
+            }
+        }
+    }
+}

--- a/src/Particular.Analyzers/DictionaryKeysAnalyzer.cs
+++ b/src/Particular.Analyzers/DictionaryKeysAnalyzer.cs
@@ -36,7 +36,7 @@
             context.RegisterSyntaxNodeAction(c => AnalyzeClassDeclaration(c, knownTypes), SyntaxKind.ClassDeclaration);
         }
 
-        void AnalyzeProperty(SymbolAnalysisContext context, KnownTypes knownTypes)
+        static void AnalyzeProperty(SymbolAnalysisContext context, KnownTypes knownTypes)
         {
             if (context.Symbol is IPropertySymbol prop)
             {
@@ -47,7 +47,7 @@
             }
         }
 
-        void AnalyzeField(SymbolAnalysisContext context, KnownTypes knownTypes)
+        static void AnalyzeField(SymbolAnalysisContext context, KnownTypes knownTypes)
         {
             if (context.Symbol is IFieldSymbol field)
             {
@@ -58,7 +58,7 @@
             }
         }
 
-        void AnalyzeMethod(SymbolAnalysisContext context, KnownTypes knownTypes)
+        static void AnalyzeMethod(SymbolAnalysisContext context, KnownTypes knownTypes)
         {
             if (context.Symbol is IMethodSymbol method)
             {
@@ -89,7 +89,7 @@
             }
         }
 
-        void AnalyzeVariableDeclaration(SyntaxNodeAnalysisContext context, KnownTypes knownTypes)
+        static void AnalyzeVariableDeclaration(SyntaxNodeAnalysisContext context, KnownTypes knownTypes)
         {
             if (context.Node is LocalDeclarationStatementSyntax vDec)
             {
@@ -119,7 +119,7 @@
             }
         }
 
-        void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, KnownTypes knownTypes)
+        static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context, KnownTypes knownTypes)
         {
             if (context.Node is ClassDeclarationSyntax classDec)
             {
@@ -137,8 +137,7 @@
             }
         }
 
-        TSyntaxType? GetNearest<TSyntaxType>(ISymbol symbol, CancellationToken cancellationToken)
-            where TSyntaxType : SyntaxNode
+        static TSyntaxType? GetNearest<TSyntaxType>(ISymbol symbol, CancellationToken cancellationToken) where TSyntaxType : SyntaxNode
         {
             if (symbol.DeclaringSyntaxReferences.Length == 0)
             {
@@ -151,7 +150,7 @@
             return syntax;
         }
 
-        void AnalyzeType(KnownTypes knownTypes, ITypeSymbol type, SyntaxNode syntax, Action<Diagnostic> reportDiagnostic)
+        static void AnalyzeType(KnownTypes knownTypes, ITypeSymbol type, SyntaxNode syntax, Action<Diagnostic> reportDiagnostic)
         {
             if (type is IArrayTypeSymbol arrayType)
             {
@@ -202,7 +201,9 @@
         class KnownTypes
         {
             public ImmutableHashSet<INamedTypeSymbol> DictionaryTypes { get; }
+
             public INamedTypeSymbol String { get; }
+
             public INamedTypeSymbol IEquatableT { get; }
 
             public KnownTypes(Compilation compilation)

--- a/src/Particular.Analyzers/DroppedTaskAnalyzer.cs
+++ b/src/Particular.Analyzers/DroppedTaskAnalyzer.cs
@@ -22,13 +22,13 @@
 
         static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is InvocationExpressionSyntax invocation))
+            if (context.Node is not InvocationExpressionSyntax invocation)
             {
                 return;
             }
 
             // cheapest checks first
-            if (!(invocation.Parent is ExpressionStatementSyntax))
+            if (invocation.Parent is not ExpressionStatementSyntax)
             {
                 return;
             }
@@ -38,7 +38,7 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context, ISymbol expression, InvocationExpressionSyntax invocation)
         {
-            if (!(expression.GetMethodOrDefault() is IMethodSymbol method))
+            if (expression.GetMethodOrDefault() is not IMethodSymbol method)
             {
                 return;
             }

--- a/src/Particular.Analyzers/DroppedTaskAnalyzer.cs
+++ b/src/Particular.Analyzers/DroppedTaskAnalyzer.cs
@@ -33,7 +33,10 @@
                 return;
             }
 
-            Analyze(context, context.SemanticModel.GetSymbolInfo(invocation.Expression, context.CancellationToken).Symbol, invocation);
+            if (context.SemanticModel.GetSymbolInfo(invocation.Expression, context.CancellationToken).Symbol is ISymbol symbol)
+            {
+                Analyze(context, symbol, invocation);
+            }
         }
 
         static void Analyze(SyntaxNodeAnalysisContext context, ISymbol expression, InvocationExpressionSyntax invocation)

--- a/src/Particular.Analyzers/Extensions/MethodSymbolExtensions.cs
+++ b/src/Particular.Analyzers/Extensions/MethodSymbolExtensions.cs
@@ -13,21 +13,11 @@
 
         static bool IsTestAttribute(string typeName)
         {
-            switch (typeName)
+            return typeName switch
             {
-                case "NUnit.Framework.OneTimeSetUpAttribute":
-                case "NUnit.Framework.OneTimeTearDownAttribute":
-                case "NUnit.Framework.SetUpAttribute":
-                case "NUnit.Framework.TearDownAttribute":
-                case "NUnit.Framework.TestAttribute":
-                case "NUnit.Framework.TestCaseAttribute":
-                case "NUnit.Framework.TestCaseSourceAttribute":
-                case "NUnit.Framework.TheoryAttribute":
-                case "Xunit.FactAttribute":
-                    return true;
-                default:
-                    return false;
-            }
+                "NUnit.Framework.OneTimeSetUpAttribute" or "NUnit.Framework.OneTimeTearDownAttribute" or "NUnit.Framework.SetUpAttribute" or "NUnit.Framework.TearDownAttribute" or "NUnit.Framework.TestAttribute" or "NUnit.Framework.TestCaseAttribute" or "NUnit.Framework.TestCaseSourceAttribute" or "NUnit.Framework.TheoryAttribute" or "Xunit.FactAttribute" => true,
+                _ => false,
+            };
         }
 
         public static bool IsEntryPoint(this IMethodSymbol method) =>

--- a/src/Particular.Analyzers/Extensions/MethodSymbolExtensions.cs
+++ b/src/Particular.Analyzers/Extensions/MethodSymbolExtensions.cs
@@ -8,7 +8,7 @@
         public static bool IsTest(this IMethodSymbol method) =>
             method != null && method.GetAttributes().Any(attribute => IsTestAttribute(attribute.AttributeClass));
 
-        static bool IsTestAttribute(INamedTypeSymbol type) =>
+        static bool IsTestAttribute(INamedTypeSymbol? type) =>
             type != null && (IsTestAttribute(type.ToString()) || IsTestAttribute(type.BaseType));
 
         static bool IsTestAttribute(string typeName)

--- a/src/Particular.Analyzers/Extensions/SemanticModelExtensions.cs
+++ b/src/Particular.Analyzers/Extensions/SemanticModelExtensions.cs
@@ -1,13 +1,13 @@
 ﻿namespace Particular.Analyzers.Extensions
 {
+    using System.Threading;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Microsoft.CodeAnalysis;
-    using System.Threading;
 
     static class SemanticModelExtensions
     {
-        public static IMethodSymbol GetMethod(this SemanticModel semanticModel, MemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken, out ISymbol declaredSymbol)
+        public static IMethodSymbol? GetMethod(this SemanticModel semanticModel, MemberDeclarationSyntax declarationSyntax, CancellationToken cancellationToken, out ISymbol? declaredSymbol)
         {
             switch (declarationSyntax)
             {
@@ -23,11 +23,11 @@
             }
         }
 
-        public static IMethodSymbol GetInvokeMethod(this SemanticModel semanticModel, DelegateDeclarationSyntax declarationSyntax, CancellationToken cancellationToken, out ISymbol declaredSymbol)
+        public static IMethodSymbol? GetInvokeMethod(this SemanticModel semanticModel, DelegateDeclarationSyntax declarationSyntax, CancellationToken cancellationToken, out ISymbol? declaredSymbol)
         {
             var @delegate = semanticModel.GetDeclaredSymbol(declarationSyntax, cancellationToken);
             declaredSymbol = @delegate;
-            return @delegate.DelegateInvokeMethod;
+            return @delegate?.DelegateInvokeMethod;
         }
     }
 }

--- a/src/Particular.Analyzers/Extensions/SymbolExtensions.cs
+++ b/src/Particular.Analyzers/Extensions/SymbolExtensions.cs
@@ -6,21 +6,15 @@
     {
         public static IMethodSymbol GetMethodOrDefault(this ISymbol symbol)
         {
-            switch (symbol)
+            return symbol switch
             {
-                case IFieldSymbol field when field.Type is INamedTypeSymbol type:
-                    return type.DelegateInvokeMethod;
-                case ILocalSymbol local when local.Type is INamedTypeSymbol type:
-                    return type.DelegateInvokeMethod;
-                case IMethodSymbol method:
-                    return method;
-                case IParameterSymbol param when param.Type is INamedTypeSymbol type:
-                    return type.DelegateInvokeMethod;
-                case IPropertySymbol property when property.Type is INamedTypeSymbol type:
-                    return type.DelegateInvokeMethod;
-                default:
-                    return null;
-            }
+                IFieldSymbol field when field.Type is INamedTypeSymbol type => type.DelegateInvokeMethod,
+                ILocalSymbol local when local.Type is INamedTypeSymbol type => type.DelegateInvokeMethod,
+                IMethodSymbol method => method,
+                IParameterSymbol param when param.Type is INamedTypeSymbol type => type.DelegateInvokeMethod,
+                IPropertySymbol property when property.Type is INamedTypeSymbol type => type.DelegateInvokeMethod,
+                _ => null,
+            };
         }
     }
 }

--- a/src/Particular.Analyzers/Extensions/SymbolExtensions.cs
+++ b/src/Particular.Analyzers/Extensions/SymbolExtensions.cs
@@ -4,7 +4,7 @@
 
     public static class SymbolExtensions
     {
-        public static IMethodSymbol GetMethodOrDefault(this ISymbol symbol)
+        public static IMethodSymbol? GetMethodOrDefault(this ISymbol symbol)
         {
             return symbol switch
             {

--- a/src/Particular.Analyzers/Extensions/TypeSymbolExtensions.cs
+++ b/src/Particular.Analyzers/Extensions/TypeSymbolExtensions.cs
@@ -6,10 +6,10 @@
 
     public static class TypeSymbolExtensions
     {
-        public static bool IsCancellationToken(this ITypeSymbol type) =>
+        public static bool IsCancellationToken(this ITypeSymbol? type) =>
             type?.ToString() == "System.Threading.CancellationToken";
 
-        public static bool IsCancellableContext(this ITypeSymbol type)
+        public static bool IsCancellableContext(this ITypeSymbol? type)
         {
             if (type == null)
             {
@@ -32,23 +32,23 @@
         static bool IsCancellableContext(string type) =>
             type == "NServiceBus.ICancellableContext";
 
-        public static bool IsTask(this ITypeSymbol type) =>
+        public static bool IsTask(this ITypeSymbol? type) =>
             type != null && (IsTask(type.ToString()) || type.BaseType.IsTask());
 
-        static bool IsTask(string type) =>
+        static bool IsTask(string? type) =>
             type != null &&
             (type == "System.Threading.Tasks.Task" ||
                 type == "System.Threading.Tasks.ValueTask" ||
                 type.StartsWith("System.Threading.Tasks.ValueTask<", StringComparison.Ordinal));
 
-        public static bool IsConfiguredTaskAwaitable(this ITypeSymbol type) =>
+        public static bool IsConfiguredTaskAwaitable(this ITypeSymbol? type) =>
             type != null && IsConfiguredTaskAwaitable(type.ToString());
 
         static bool IsConfiguredTaskAwaitable(string type) =>
             type == "System.Runtime.CompilerServices.ConfiguredTaskAwaitable" ||
             type.StartsWith("System.Runtime.CompilerServices.ConfiguredTaskAwaitable<", StringComparison.Ordinal);
 
-        public static bool IsFunc(this INamedTypeSymbol type) =>
+        public static bool IsFunc(this INamedTypeSymbol? type) =>
             type != null && type.TypeArguments.Length > 0 && type.ToString().StartsWith("System.Func<", StringComparison.Ordinal);
     }
 }

--- a/src/Particular.Analyzers/LoggingAnalyzer.cs
+++ b/src/Particular.Analyzers/LoggingAnalyzer.cs
@@ -82,12 +82,12 @@
         {
             var loggerSymbol = context.SemanticModel.GetSymbolInfo(invocationSyntax, context.CancellationToken).Symbol;
 
-            if (loggerSymbol.GetMethodOrDefault() is not IMethodSymbol method)
+            if (loggerSymbol is null || loggerSymbol.GetMethodOrDefault() is not IMethodSymbol method)
             {
                 return false;
             }
 
-            if (method.ReceiverType.ToString() != loggerFullName)
+            if (method is null || method.ReceiverType?.ToString() != loggerFullName)
             {
                 return false;
             }

--- a/src/Particular.Analyzers/LoggingAnalyzer.cs
+++ b/src/Particular.Analyzers/LoggingAnalyzer.cs
@@ -46,17 +46,17 @@
 
         static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is InvocationExpressionSyntax invocation))
+            if (context.Node is not InvocationExpressionSyntax invocation)
             {
                 return;
             }
 
-            if (!(invocation.Expression is MemberAccessExpressionSyntax memberAccess))
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
             {
                 return;
             }
 
-            if (!(memberAccess.Name is IdentifierNameSyntax identifierName))
+            if (memberAccess.Name is not IdentifierNameSyntax identifierName)
             {
                 return;
             }
@@ -82,7 +82,7 @@
         {
             var loggerSymbol = context.SemanticModel.GetSymbolInfo(invocationSyntax, context.CancellationToken).Symbol;
 
-            if (!(loggerSymbol.GetMethodOrDefault() is IMethodSymbol method))
+            if (loggerSymbol.GetMethodOrDefault() is not IMethodSymbol method)
             {
                 return false;
             }
@@ -100,10 +100,10 @@
                 var p = method.Parameters[i];
                 if (formatIndex < 0)
                 {
-                    if (p.Name == "message" || p.Name == "format")
+                    if (p.Name is "message" or "format")
                     {
                         var typeString = p.Type.ToString();
-                        if (typeString == "string" || typeString == "string?")
+                        if (typeString is "string" or "string?")
                         {
                             formatIndex = i;
                         }
@@ -114,7 +114,7 @@
                     if (p.Type is IArrayTypeSymbol arrayType)
                     {
                         var elementType = arrayType.ElementType.ToString();
-                        if (elementType == "object" || elementType == "object?")
+                        if (elementType is "object" or "object?")
                         {
                             argsIndex = i;
                             break;

--- a/src/Particular.Analyzers/Particular.Analyzers.csproj
+++ b/src/Particular.Analyzers/Particular.Analyzers.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Particular.Analyzers/Particular.Analyzers.csproj
+++ b/src/Particular.Analyzers/Particular.Analyzers.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Particular.Analyzers/Particular.Analyzers.csproj
+++ b/src/Particular.Analyzers/Particular.Analyzers.csproj
@@ -16,12 +16,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.1.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.7/cs" Link="$(AssemblyName).dll" Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.8/cs" Link="$(AssemblyName).dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="UseMajorMinorPatchForAssemblyVersion" AfterTargets="MinVer">

--- a/src/Particular.Analyzers/TypeNameAnalyzer.cs
+++ b/src/Particular.Analyzers/TypeNameAnalyzer.cs
@@ -28,7 +28,7 @@
 
         static void Analyze(SyntaxNodeAnalysisContext context)
         {
-            if (!(context.Node is MemberDeclarationSyntax type))
+            if (context.Node is not MemberDeclarationSyntax type)
             {
                 return;
             }


### PR DESCRIPTION
Prevents a dictionary key from being a reference type that doesn't implement `IEquatable<T>`. Would have prevented bugs like https://github.com/Particular/NServiceBus.SqlServer/issues/1284.

I also was having a bit of difficulty with tests, and got tired of this being the only repo in the organization that doesn't use NUnit, which makes it harder to borrow concepts here that we already have developed in the NServiceBus repo analyzer test framework, so I swapped to NUnit to facilitate that as well.