### PR TITLE
New analyzer fixes

### DIFF
--- a/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
@@ -123,5 +123,23 @@
             return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
         }
 #endif
+
+        [Test]
+        public Task IgnoreGenericParameters()
+        {
+            var code = """
+                using System.Collections.Generic;
+
+                public static class Extensions
+                {
+                    public static void GoodExtensionMethod<T>(this HashSet<T> set)
+                    {
+                        // User will be warned on the type they are trying to use the method on
+                    }
+                }
+                """;
+
+            return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
+        }
     }
 }

--- a/src/Particular.Analyzers/DictionaryKeysAnalyzer.cs
+++ b/src/Particular.Analyzers/DictionaryKeysAnalyzer.cs
@@ -178,6 +178,12 @@
                 return true;
             }
 
+            if (type is ITypeParameterSymbol)
+            {
+                // Especially on extension methods and whatnot, the user will be warned on whatever concrete type they're using
+                return true;
+            }
+
             var implementsIEquatable = type.Interfaces
                 .Any(iface => iface.IsGenericType && iface.ConstructedFrom.Equals(knownTypes.IEquatableT, SymbolEqualityComparer.Default));
 


### PR DESCRIPTION
Don't flag, for instance, a `HashSet<T>`. It should be presumed that in most cases, the location where the user turns this into a non-generic type will be flagged instead.