### PR TITLE
Allow hash key types when the constructor specifies an IEqualityComparer<T>

### DIFF
--- a/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
+++ b/src/Particular.Analyzers.Tests/DictionaryKeyAnalyzerTests.cs
@@ -141,5 +141,53 @@
 
             return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
         }
+
+        [Test]
+        public Task IgnoreWhenCustomComparerInUse()
+        {
+            var code = """
+                using System.Collections.Generic;
+
+                public class CustomType
+                {
+                    public int Value { get; set; }
+                }
+                public class CustomComparer : IEqualityComparer<CustomType>
+                {
+                    public bool Equals(CustomType x, CustomType y) => x.Value == y.Value;
+                    public int GetHashCode(CustomType obj) => obj.Value.GetHashCode();
+                    public static readonly CustomComparer Instance = new CustomComparer();
+                    public static CustomComparer Create() => new CustomComparer();
+                }
+                public class Foo
+                {
+                    public void Bar()
+                    {
+                        var badSet1 = new [|HashSet<CustomType>|]();
+                        [|HashSet<CustomType>|] badSet2 = new();
+
+                        var goodSet1 = new HashSet<CustomType>(new CustomComparer());
+                        HashSet<CustomType> goodSet2 = new(new CustomComparer());
+
+                        var goodSet3 = new HashSet<CustomType>(CustomComparer.Instance);
+                        HashSet<CustomType> goodSet4 = new(CustomComparer.Instance);
+
+                        // Multiple declarators are rare but technically possible
+                        // Note that implicitly typed variables (using var) cannot have multiple declarators like this
+                        [|HashSet<CustomType>|] badMult1 = new [|HashSet<CustomType>|](),
+                                            badMult2 = new(),
+                                            badMult3 = new(CustomComparer.Instance); // This is OK but still have to flag the initial type declaration
+
+
+                        HashSet<CustomType> goodMult1 = new HashSet<CustomType>(new CustomComparer()),
+                                            goodMult2 = new(CustomComparer.Instance);
+
+                        var comparerViaMethod = new HashSet<CustomType>(CustomComparer.Create());
+                    }
+                }
+                """;
+
+            return Assert(code, DiagnosticIds.DictionaryHasUnsupportedKeyType);
+        }
     }
 }


### PR DESCRIPTION
Allows code like: `new HashSet<CustomType>(new CustomComparer())` as the passed in type that implements `IEqualityComparer<T>` makes up for the lack of the key type implementing `IEquatable<T>`.